### PR TITLE
Use lazy module and add a wait_for_writeback decorator

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+Unreleased Changes
+------------------
+
+* `component.trigger('writeback') <https://github.com/anvilistas/anvil-extras/pull/47>`_
+* `MultiSelectDropDown component <https://github.com/anvilistas/anvil-extras/pull/44>`_
+* `@wait_for_writeback decorator <https://github.com/anvilistas/anvil-extras/pull/50>`_
+
+
 v1.1.0 27-Mar-2021
 ------------------
 

--- a/client_code/utils/__init__.py
+++ b/client_code/utils/__init__.py
@@ -1,0 +1,55 @@
+# MIT License
+#
+# Copyright (c) 2021 The Anvil Extras project team members listed at
+# https://github.com/anvilistas/anvil-extras/graphs/contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# This software is published at https://github.com/anvilistas/anvil-extras
+
+from functools import cache
+
+__version__ = "1.1.0"
+
+
+def __dir__():
+    return ["auto_refreshing", "wait_for_writeback", "timed", "BindingRefreshDict"]
+
+
+@cache
+def __getattr__(name):
+    # todo use dynamic imports but __import__ is not yet supported in skult
+    if name == "auto_refreshing":
+        from ._auto_refreshing import auto_refreshing
+
+        return auto_refreshing
+    elif name == "timed":
+        from ._timed import timed
+
+        return timed
+    elif name == "wait_for_writeback":
+        from ._writeback_waiter import wait_for_writeback
+
+        return wait_for_writeback
+    elif name == "BindingRefreshDict":
+        from ._auto_refreshing import BindingRefreshDict
+
+        return BindingRefreshDict
+    else:
+        raise AttributeError(name)

--- a/client_code/utils/_auto_refreshing.py
+++ b/client_code/utils/_auto_refreshing.py
@@ -22,40 +22,12 @@
 # SOFTWARE.
 #
 # This software is published at https://github.com/anvilistas/anvil-extras
-from time import gmtime, strftime, time
+
+
+from functools import cache
 
 __version__ = "1.1.0"
 
-
-def _signature(func, args, kwargs):
-    """Text representation of a function's signature"""
-    arguments = [str(a) for a in args]
-    arguments.extend([f"{key}={value}" for key, value in kwargs.items()])
-    return f"{func.__name__}({','.join(arguments)})"
-
-
-def _timestamp(seconds):
-    """Text representation of a unix timestamp"""
-    return strftime("%Y-%m-%d %H:%M:%S", gmtime(seconds))
-
-
-def timed(func):
-    """A decorator to time the execution of a function"""
-
-    def wrapper(*args, **kwargs):
-        signature = _signature(func, args, kwargs)
-        started_at = time()
-        print(f"{_timestamp(started_at)} {signature} called")
-        result = func(*args, **kwargs)
-        finished_at = time()
-        duration = f"{(finished_at - started_at):.2f}s"
-        print(f"{_timestamp(finished_at)} {signature} completed({duration})")
-        return result
-
-    return wrapper
-
-
-_cls_cache = set()
 _dict_setitem = dict.__setitem__
 
 
@@ -96,9 +68,8 @@ def _item_override(cls):
     return property(item_getter, item_setter)
 
 
+@cache
 def auto_refreshing(cls):
     """A decorator for a form class to refresh data bindings automatically"""
-    if cls not in _cls_cache:
-        cls.item = _item_override(cls)
-        _cls_cache.add(cls)
+    cls.item = _item_override(cls)
     return cls

--- a/client_code/utils/_timed.py
+++ b/client_code/utils/_timed.py
@@ -1,0 +1,59 @@
+# MIT License
+#
+# Copyright (c) 2021 The Anvil Extras project team members listed at
+# https://github.com/anvilistas/anvil-extras/graphs/contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# This software is published at https://github.com/anvilistas/anvil-extras
+
+
+from functools import wraps
+from time import gmtime, strftime, time
+
+__version__ = "1.1.0"
+
+
+def _signature(func, args, kwargs):
+    """Text representation of a function's signature"""
+    arguments = [str(a) for a in args]
+    arguments.extend([f"{key}={value}" for key, value in kwargs.items()])
+    return f"{func.__name__}({','.join(arguments)})"
+
+
+def _timestamp(seconds):
+    """Text representation of a unix timestamp"""
+    return strftime("%Y-%m-%d %H:%M:%S", gmtime(seconds))
+
+
+def timed(func):
+    """A decorator to time the execution of a function"""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        signature = _signature(func, args, kwargs)
+        started_at = time()
+        print(f"{_timestamp(started_at)} {signature} called")
+        result = func(*args, **kwargs)
+        finished_at = time()
+        duration = f"{(finished_at - started_at):.2f}s"
+        print(f"{_timestamp(finished_at)} {signature} completed({duration})")
+        return result
+
+    return wrapper

--- a/client_code/utils/_writeback_waiter.py
+++ b/client_code/utils/_writeback_waiter.py
@@ -1,0 +1,90 @@
+# MIT License
+#
+# Copyright (c) 2021 The Anvil Extras project team members listed at
+# https://github.com/anvilistas/anvil-extras/graphs/contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# This software is published at https://github.com/anvilistas/anvil-extras
+
+from functools import cache, wraps
+
+from anvil.js.window import Function, anvilFormTemplates
+
+__version__ = "1.1.0"
+
+_store_writebacks = Function(
+    "form",
+    """
+    const self = PyDefUtils.unwrapOrRemapToPy(form);
+    const bindings = self._anvil.dataBindings || [];
+    const activeWritebacks = bindings.map(() => null);
+
+    bindings.forEach(({pyComponent}, i) => {
+        const bindingFunc = pyComponent._anvil.dataBindingWriteback;
+        const wrapper = (component, name, val) => {
+            const res = bindingFunc(component, name, val).finally(() => {
+                activeWritebacks[i] = null;
+            });
+            activeWritebacks[i] = res;
+            return res;
+        };
+        pyComponent._anvil.dataBindingWriteback = wrapper;
+    });
+
+    self._anvil.activeWritebacks = activeWritebacks;
+""",
+)
+
+_wait_for_writeback = Function(
+    "form",
+    """
+    const self = PyDefUtils.unwrapOrRemapToPy(form);
+    return new Promise((resolve) => {
+        setTimeout(() => resolve(Promise.allSettled(self._anvil.activeWritebacks.slice(0))));
+    }).then(() => Sk.builtin.none.none$);
+""",
+)
+
+
+def _init_wrapper(init):
+    @wraps(init)
+    def wrapper(self, *args, **kwargs):
+        _store_writebacks(self)
+        return init(self, *args, **kwargs)
+
+    return wrapper
+
+
+@cache
+def _init_writeback(template):
+    template.init_components = template.__init__ = _init_wrapper(template.__init__)
+
+
+for template in anvilFormTemplates:
+    _init_writeback(template)
+
+
+def wait_for_writeback(fn):
+    @wraps(fn)
+    def wrapper(self, *args, **kwargs):
+        _wait_for_writeback(self)
+        return fn(self, *args, **kwargs)
+
+    return wrapper

--- a/docs/guides/modules/utils.rst
+++ b/docs/guides/modules/utils.rst
@@ -8,7 +8,7 @@ There are client and server side decorators which you can use to show that a fun
 
 Client Code
 ^^^^^^^^^^^
-Import the `timed` decorator and apply it to a function:
+Import the ``timed`` decorator and apply it to a function:
 
 .. code-block:: python
 
@@ -22,7 +22,7 @@ When the decorated function is called, you will see messages in the IDE console 
 
 Server Code
 ^^^^^^^^^^^
-Import the `timed` decorator and apply it to a function:
+Import the ``timed`` decorator and apply it to a function:
 
 .. code-block:: python
 
@@ -35,7 +35,7 @@ Import the `timed` decorator and apply it to a function:
    def target_function(args, **kwargs):
        print("hello world")
 
-On the server side, the decorator takes a `logging.Logger` instance as one of its optional arguments. The default instance will log to stdout, so that messages will appear in your app's logs and in the IDE console. You can, however, create your own logger and pass that instead if you need more sophisticated behaviour:
+On the server side, the decorator takes a ``logging.Logger`` instance as one of its optional arguments. The default instance will log to stdout, so that messages will appear in your app's logs and in the IDE console. You can, however, create your own logger and pass that instead if you need more sophisticated behaviour:
 
 .. code-block:: python
 
@@ -50,13 +50,13 @@ On the server side, the decorator takes a `logging.Logger` instance as one of it
    def target_function(args, **kwargs):
        ...
 
-The decorator also takes an optional `level` argument which must be one of the standard levels from the logging module. When no argument is passed, the default level is `logging.INFO`.
+The decorator also takes an optional ``level`` argument which must be one of the standard levels from the logging module. When no argument is passed, the default level is ``logging.INFO``.
 
 Auto-Refresh
 ------------
-Whenever you set a form's `item` attribute, the form's `refresh_data_bindings` method is called automatically.
+Whenever you set a form's ``item`` attribute, the form's ``refresh_data_bindings`` method is called automatically.
 
-The `utils` module includes a decorator you can add to a form's class so that `refresh_data_bindings` is called whenever `item` changes at all.
+The ``utils`` module includes a decorator you can add to a form's class so that ``refresh_data_bindings`` is called whenever ``item`` changes at all.
 
 To use it, import the decorator and apply it to the class for a form:
 
@@ -71,4 +71,27 @@ To use it, import the decorator and apply it to the class for a form:
        def __init__(self, **properties):
            self.init_components(**properties)
 
-Now, the form has an `item` property which behaves like a dictionary. Whenever a value of that dictionary changes, the form's `refresh_data_bindings` method will be called.
+Now, the form has an ``item`` property which behaves like a dictionary. Whenever a value of that dictionary changes, the form's ``refresh_data_bindings`` method will be called.
+
+
+Wait for writeback
+------------
+Using ``wait_for_writeback`` as a decorator prevents a function executing before any queued writebacks have completed.
+
+This is particularly useful if you have a form with text fields. Race condidtions can occur between a text field writing back to an item and a click event that uses the item.
+
+To use ``wait_for_writeback``, import the decorator and apply it to a function, usually an event_handler:
+
+.. code-block:: python
+
+   from anvil_extras.utils import wait_for_writeback
+
+   class MyForm(MyFormTemplate):
+        ...
+
+        @wait_for_writeback
+        def button_1_click(self, **event_args):
+            anvil.server.call("save_item", self.item)
+
+
+The click event will now only be called after all active writebacks have finished executing.


### PR DESCRIPTION
This pr does 2 things
1. Makes the util module lazy
2. includes the `wait_for_writeback` decorator


Inspired by [this post](https://anvil.works/forum/t/form-field-in-repeating-panel-not-updating-value-on-loss-of-focus-on-touch-devices/8489)

It's not just mobile
The lost focus writeback can happen after the click and then the item in the click handler is wrong!

It can be used in the following way:

```python
from anvil_extras.util import wait_for_writeback

class Form1(Form1Template):
  ...

  @wait_for_writeback
  def button_1_click(self, **event_args):
    """This method is called when the button is clicked"""
    anvil.server.call('save_item', self.item)

```


---

### how it works

- All anvilTemplate forms are stored in `window.anvilFormTemplates` 
- each template has a private javascript list of databindings where each item includes the component.
- each component has a private javascript attribute with its writebackDataBinding function
- We walk over the list of bindings and store a null value in a new list `activeWritebacks`
- when a writeback is executed the wrapper puts the result, from the original writeback call, into the `activeWritebacks` array
- the result of the original writeback call is a Promise to be resolved

Then
- If the `@wait_for_writeback` decorator is used...
- We use a call to setTimeout to copy the list of active Writebacks.
- using setTimeout here allows writebacks in the queue to propogate.
- We then wait for all the Promises to settle (they either resolve or reject)
- the wrapped function is called safe in the knowledge that the item is correct




