### PR TITLE
Remove get_uid where possible

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,11 +1,20 @@
 Unreleased Changes
 ------------------
+
+New Features
+============
 * `Update styling of switch component <https://github.com/anvilistas/anvil-extras/pull/56>`_
 * `Include pagination_click event in augment module <https://github.com/anvilistas/anvil-extras/pull/55>`_
+
+Changes
+=======
+* `Refactor of progress bars <https://github.com/anvilistas/anvil-extras/pull/59>`_
 
 v1.2.0 25-May-2021
 ------------------
 
+New Features
+============
 * `component.trigger('writeback') <https://github.com/anvilistas/anvil-extras/pull/47>`_
 * `MultiSelectDropDown component <https://github.com/anvilistas/anvil-extras/pull/44>`_
 * `@wait_for_writeback decorator <https://github.com/anvilistas/anvil-extras/pull/50>`_
@@ -16,6 +25,8 @@ v1.2.0 25-May-2021
 v1.1.0 27-Mar-2021
 ------------------
 
+New Features
+============
 * `Auto Refreshing Item <https://github.com/anvilistas/anvil-extras/pull/39>`_
 
 v1.0.0 11-Mar-2021

--- a/client_code/ProgressBar/Determinate/__init__.py
+++ b/client_code/ProgressBar/Determinate/__init__.py
@@ -5,6 +5,7 @@
 #
 # This software is published at https://github.com/anvilistas/anvil-extras
 from anvil.js import get_dom_node
+
 from anvil_extras import ProgressBar, session
 
 from ._anvil_designer import DeterminateTemplate

--- a/client_code/ProgressBar/Determinate/__init__.py
+++ b/client_code/ProgressBar/Determinate/__init__.py
@@ -4,8 +4,7 @@
 # https://github.com/anvilistas/anvil-extras/graphs/contributors
 #
 # This software is published at https://github.com/anvilistas/anvil-extras
-from anvil.js.window import document
-
+from anvil.js import get_dom_node
 from anvil_extras import ProgressBar, session
 
 from ._anvil_designer import DeterminateTemplate
@@ -17,22 +16,9 @@ session.style_injector.inject(ProgressBar.css)
 
 class Determinate(DeterminateTemplate):
     def __init__(self, track_colour, indicator_colour, **properties):
-        self.uid = session.get_uid()
-        css = f"""
-:root {{
-  --progress-{self.uid}: 50%;
-}}
-
-.anvil-role-progress-indicator-{self.uid} {{
-  width: var(--progress-{self.uid});
-}}
-        """
-        session.style_injector.inject(css)
+        self.indicator_dom_node = get_dom_node(self.indicator_panel)
         self.role = "progress-track"
-        self.indicator_panel.role = [
-            "progress-indicator",
-            f"progress-indicator-{self.uid}",
-        ]
+        self.indicator_panel.role = "progress-indicator"
         self.background = track_colour
         self.indicator_panel.background = indicator_colour
         self.init_components(**properties)
@@ -44,4 +30,4 @@ class Determinate(DeterminateTemplate):
     @progress.setter
     def progress(self, value):
         self._progress = value
-        document.body.style.setProperty(f"--progress-{self.uid}", f"{value:%}")
+        self.indicator_dom_node.style.setProperty("width", f"{value:%}")

--- a/client_code/ProgressBar/Indeterminate/__init__.py
+++ b/client_code/ProgressBar/Indeterminate/__init__.py
@@ -19,7 +19,7 @@ class Indeterminate(IndeterminateTemplate):
     def __init__(self, track_colour, indicator_colour, **properties):
         dom_node = get_dom_node(self)
         dom_node.style.setProperty("background-color", indicator_colour)
-        
+
         self.uid = session.get_uid()
         css = f"""
 .anvil-role-indeterminate-progress-indicator-{self.uid}:before {{

--- a/client_code/ProgressBar/Indeterminate/__init__.py
+++ b/client_code/ProgressBar/Indeterminate/__init__.py
@@ -5,6 +5,8 @@
 #
 # This software is published at https://github.com/anvilistas/anvil-extras
 from anvil_extras import ProgressBar, session
+from anvil.js import get_dom_node
+from anvil.js.window import document
 
 from ._anvil_designer import IndeterminateTemplate
 
@@ -15,15 +17,13 @@ session.style_injector.inject(ProgressBar.css)
 
 class Indeterminate(IndeterminateTemplate):
     def __init__(self, track_colour, indicator_colour, **properties):
+        dom_node = get_dom_node(self)
+        dom_node.style.setProperty("background-color", indicator_colour)
+        
         self.uid = session.get_uid()
         css = f"""
-.anvil-role-indeterminate-progress-indicator-{self.uid} {{
-  background-colour: {indicator_colour}
-}}
-
 .anvil-role-indeterminate-progress-indicator-{self.uid}:before {{
   background-color: {track_colour}
-
 }}
 """
         session.style_injector.inject(css)

--- a/client_code/ProgressBar/Indeterminate/__init__.py
+++ b/client_code/ProgressBar/Indeterminate/__init__.py
@@ -4,9 +4,10 @@
 # https://github.com/anvilistas/anvil-extras/graphs/contributors
 #
 # This software is published at https://github.com/anvilistas/anvil-extras
-from anvil_extras import ProgressBar, session
 from anvil.js import get_dom_node
 from anvil.js.window import document
+
+from anvil_extras import ProgressBar, session
 
 from ._anvil_designer import IndeterminateTemplate
 

--- a/client_code/ProgressBar/Indeterminate/__init__.py
+++ b/client_code/ProgressBar/Indeterminate/__init__.py
@@ -21,17 +21,14 @@ class Indeterminate(IndeterminateTemplate):
         dom_node = get_dom_node(self)
         dom_node.style.setProperty("background-color", indicator_colour)
 
-        self.uid = session.get_uid()
+        indicator_id = session.get_dom_node_id(self.indicator_panel)
         css = f"""
-.anvil-role-indeterminate-progress-indicator-{self.uid}:before {{
+#{indicator_id}:before {{
   background-color: {track_colour}
 }}
 """
         session.style_injector.inject(css)
         self.role = "progress-track"
-        self.indicator_panel.role = [
-            "indeterminate-progress-indicator",
-            f"indeterminate-progress-indicator-{self.uid}",
-        ]
+        self.indicator_panel.role = "indeterminate-progress-indicator"
         self.indicator_panel.background = indicator_colour
         self.init_components(**properties)

--- a/client_code/session.py
+++ b/client_code/session.py
@@ -6,13 +6,18 @@
 # This software is published at https://github.com/anvilistas/anvil-extras
 import random
 
+from anvil.js import get_dom_node
+
 from . import style
 
 __version__ = "1.2.0"
+characters = "abcdefghijklmnopqrstuvwxyz0123456789"
 
 style_injector = style.Injector()
 
 
-def get_uid(length=8):
-    characters = "abcdefghijklmnopqrstuvwxyz0123456789"
-    return "".join([random.choice(characters) for _ in range(length)])
+def get_dom_node_id(component):
+    node = get_dom_node(component)
+    if not node.id:
+        node.id = "".join([random.choice(characters) for _ in range(8)])
+    return node.id


### PR DESCRIPTION
I've removed get_uid entirely from the determinate progress bar but I can't find a clean way to replace its use for the pseudo element on the indeterminate bar.