### PR TITLE
Quill - small tweaks to implementation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+## Changes
+* Quill editor supports a toolbar and theme set at runtime.
+  https://github.com/anvilistas/anvil-extras/pull/80
 # v1.4 07-June-2021
 
 ## New Features

--- a/docs/guides/components/quill.rst
+++ b/docs/guides/components/quill.rst
@@ -33,7 +33,7 @@ Properties
 
 :readonly: Boolean
 
-    Check the Quill docs. This property cannot be updated after the Quill editor has been instantiated.
+    Check the Quill docs.
 
 :spacing_above: String
 
@@ -45,12 +45,11 @@ Properties
 
 :theme: String
 
-    Quill supports ``"snow"`` or ``"bubble"`` theme. (Cannot be updated after instantiation).
+    Quill supports ``"snow"`` or ``"bubble"`` theme.
 
 :toolbar: Boolean or Object
 
-    Check the Quill docs. This property cannot be updated after the Quill editor has been instantiated.
-    If you want to use an Object you should construct the Quill instance in code.
+    Check the Quill docs. If you want to use an Object you can set this at runtime. See quill docs for examples.
 
 :visible: Boolean
 


### PR DESCRIPTION
Allows toolbar to be set at runtime
stops set_html causing a focus of quill editor
