### PR TITLE
local storage wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## New Features
+* `local_storage` - wrapper around the browser localStorage object
+  https://github.com/anvilistas/anvil-extras/pull/93
+
 ## Changes
 * Quill editor supports a toolbar and theme set at runtime.
   https://github.com/anvilistas/anvil-extras/pull/80

--- a/client_code/storage.py
+++ b/client_code/storage.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright (c) 2021 The Anvil Extras project team members listed at
+# https://github.com/anvilistas/anvil-extras/graphs/contributors
+#
+# This software is published at https://github.com/anvilistas/anvil-extras
+
+import json as _json
+
+from anvil.js import window as _window
+
+__version__ = "1.4.0"
+__all__ = ["local_storage", "session_storage"]
+
+_prefix = "anvil_storage_"
+_prefix_len = len(_prefix)
+
+
+class Storage:
+    def __init__(self, store):
+        self._store = store
+
+    def _check_store(self):
+        # in some browsers localStorage might not be available
+        # we don't throw the error until we try to access the store
+        if self._store is None:
+            raise RuntimeError("browser storage is not available")
+
+    def _mangle_key(self, key):
+        # we mangle the names so that we avoid conflicts
+        self._check_store()
+        if not isinstance(key, str):
+            raise TypeError("storage keys must be strings")
+        return key if key.startswith(_prefix) else _prefix + key
+
+    def _filter_store(self):
+        return filter(lambda key: key.startswith(_prefix), self._store.keys())
+
+    def _map_store(self, predicate):
+        self._check_store()
+        return map(predicate, self._filter_store())
+
+    def __getitem__(self, key):
+        ret = self._store.getItem(self._mangle_key(key))
+        if ret is None:
+            raise KeyError(key)
+        return _json.loads(ret)
+
+    def __setitem__(self, key, val):
+        key = self._mangle_key(key)
+        try:
+            val = _json.dumps(val)
+        except Exception as e:
+            raise type(e)(f"There was a problem converting the value into json: {e}")
+        self._store.setItem(key, val)
+
+    def __delitem__(self, key):
+        self._store.removeItem(self._mangle_key(key))
+
+    def __contains__(self, key):
+        return self._mangle_key(key) in self._store
+
+    def __repr__(self):
+        pairs = ""
+        for key, val in self.items():
+            pairs += f"{key!r}: {val!r}"
+        return f"Storage({{{pairs}}})"
+
+    def __iter__(self):
+        return self.keys()
+
+    def keys(self):
+        """returns the keys for local storage as an iterator"""
+        return self._map_store(lambda key: key[_prefix_len:])
+
+    def items(self):
+        """returns the items for local storage as an iterator"""
+        return self._map_store(lambda key: (key[_prefix_len:], self.__getitem__(key)))
+
+    def values(self):
+        """returns the values for local storage as an iterator"""
+        return self._map_store(lambda key: self.__getitem__(key))
+
+    def put(self, key, value):
+        """put a key value pair into local storage"""
+        self[key] = value
+
+    def get(self, key, default=None):
+        """get a value from local storage, returns the default value if the key is not in local storage"""
+        try:
+            return self.__getitem__(key)
+        except KeyError:
+            return default
+
+    def pop(self, key, default=None):
+        """remove specified key and return the corresponding value.\n\nIf key is not found, default is returned"""
+        try:
+            return self.get(key, default)
+        finally:
+            del self[key]
+
+
+local_storage = Storage(_window.get("localStorage"))
+session_storage = Storage(_window.get("sessionStorage"))
+
+
+if __name__ == "__main__":
+    print(local_storage)
+    for k, v in local_storage.items():
+        print(k, v)
+    local_storage["foo"] = "bar"
+    print(local_storage["foo"])
+    del local_storage["foo"]
+    print(local_storage.get("foo"))
+    try:
+        local_storage["foo"]
+    except KeyError as e:
+        print(repr(e))
+    local_storage.put("foo", 1)
+    print(local_storage.pop("foo"))
+    x = {"abc": 123}
+    local_storage["x"] = x
+    print("x" in local_storage)
+    print(local_storage["x"] == x)
+    print(local_storage.get("x") == x)
+    print(local_storage.pop("x") == x)

--- a/docs/guides/modules/storage.rst
+++ b/docs/guides/modules/storage.rst
@@ -1,19 +1,18 @@
-:mod:`storage` --- wrapper around window.Storage
-================================================
-
+Storage
+=======
 
 Introduction
 ------------
-Browsers have a localStorage and a sessionStorage object.
-The browser localStorage object persists between browser sessions, where the sessionStorage object does not.
+Browsers have a ``localStorage`` object that can store data between browser sessions
 
-The :object:`local_storage` object provides a convenient dictionary like wrapper around the javacript localStorage object.
-Similary the :object:`session_storage` provides a wrapper around the sessionStorage object.
+The anvil_extras :mod:`storage` module provides :const:`local_storage` object, which is a
+convenient dictionary like wrapper around the native browser ``localStorage`` object.
 
+The :attr:`local_storage` object can store data that persists accross browser sessions and is also available offline.
+It could be used to create an entirely offline todo app, or to store simple data across sessions.
 
-The :object:`local_storage` object is also available offline and may be convenient for storing data.
-For example - it could be used to create an entirely offline todo app, or to store simple data across sessions.
-
+(Browsers also have a ``sessionStorage`` object, and an equivalent :const:`session_storage`
+object is also available in the :mod:`storage` module.)
 
 Usage
 -----
@@ -22,6 +21,7 @@ Store user preference
 +++++++++++++++++++++
 
 .. code-block:: python
+
     from anvil_extras.storage import local_storage
 
     class UserPreferences(UserPreferencesTemplate):
@@ -36,6 +36,7 @@ Change the theme at startup
 +++++++++++++++++++++++++++
 
 .. code-block:: python
+
     ## inside a startup module
     from anvil_extras.storage import local_storage
 
@@ -45,8 +46,8 @@ Change the theme at startup
 
 
 
-local_storage
--------------
+API
+---
 
 .. object:: local_storage
 
@@ -54,16 +55,16 @@ local_storage
 
    .. describe:: list(local_storage)
 
-      Return a list of all the keys used in :object:`local_storage`.
+      Return a list of all the keys used in :attr:`local_storage`.
 
    .. describe:: len(local_storage)
 
-      Return the number of items in :object:`local_storage`.
+      Return the number of items in :attr:`local_storage`.
 
    .. describe:: local_storage[key]
 
-      Return the item of :object:`local_storage` with key *key*.  Raises a :exc:`KeyError` if *key* is
-      not in :object:`local_storage`. Raises a :exc:`TypeError` if *key* is not a string.
+      Return the item of :attr:`local_storage` with key *key*.  Raises a :exc:`KeyError` if *key* is
+      not in :attr:`local_storage`. Raises a :exc:`TypeError` if *key* is not a string.
 
    .. describe:: local_storage[key] = value
 
@@ -71,11 +72,11 @@ local_storage
 
    .. describe:: del local_storage[key]
 
-      Remove ``local_storage[key]`` from :object:`local_storage`. :exc:`KeyError` raised is NOT raised if the key is not in :object:`local_storage`.
+      Remove ``local_storage[key]`` from :attr:`local_storage`.
 
    .. describe:: key in local_storage
 
-      Return ``True`` if :object:`local_storage` has a key *key*, else ``False``.
+      Return ``True`` if :attr:`local_storage` has a key *key*, else ``False``.
 
    .. describe:: iter(local_storage)
 
@@ -84,25 +85,25 @@ local_storage
 
    .. method:: clear()
 
-      Remove all items from the dictionary.
+      Remove all items from the :attr:`local storage`.
 
    .. method:: get(key[, default])
 
-      Return the value for *key* if *key* is in :object:`local_storage`, else *default*.
+      Return the value for *key* if *key* is in :attr:`local_storage`, else *default*.
       If *default* is not given, it defaults to ``None``, so that this method
       never raises a :exc:`KeyError`.
 
    .. method:: items()
 
-      Return a map iterator of :object:`local_storage`'s (``[key, value]`` pairs).
+      Return a map iterator of :attr:`local_storage`'s ``(key, value)`` pairs.
 
    .. method:: keys()
 
-      Return a map iterator of the dictionary's keys.
+      Return a map iterator of :attr:`local storage`'s keys.
 
    .. method:: pop(key[, default])
 
-      If *key* is in :object:`local_storage`, remove it and return its value, else return
+      If *key* is in :attr:`local_storage`, remove it and return its value, else return
       *default*.  If *default* is not given, it defaults to ``None``, so that this method
       never raises a :exc:`KeyError`.
 
@@ -112,14 +113,14 @@ local_storage
 
    .. method:: update([other])
 
-      Update the :object:`local_storage` with the key/value pairs from *other*, overwriting
+      Update the :attr:`local_storage` with the key/value pairs from *other*, overwriting
       existing keys.  Return ``None``.
 
       :meth:`update` accepts either a dictionary object or an iterable of
       key/value pairs (as tuples or other iterables of length two).  If keyword
-      arguments are specified, :object:`local_storage` is then updated with those
-      key/value pairs: ``d.update(red=1, blue=2)``.
+      arguments are specified, :attr:`local_storage` is then updated with those
+      key/value pairs: ``local_storage.update(red=1, blue=2)``.
 
    .. method:: values()
 
-      Return a map iterator of :object:`local_storage`'s values.
+      Return a map iterator of :attr:`local_storage`'s values.

--- a/docs/guides/modules/storage.rst
+++ b/docs/guides/modules/storage.rst
@@ -1,0 +1,128 @@
+:mod:`storage` --- wrapper around window.Storage
+=====================================================
+
+
+Introduction
+------------
+Browsers have a localStorage and a sessionStorage object.
+The browser localStorage object persists between browser sessions, where the sessionStorage object does not.
+
+The :object:`local_storage` object provides a convenient dictionary like wrapper around the javacript localStorage object.
+Similary the :object:`session_storage` provides a wrapper around the sessionStorage object.
+
+
+The :object:`local_storage` object is also available offline and may be convenient for storing data.
+For example - it could be used to create an entirely offline todo app, or to store simple data across sessions.
+
+
+Usage
+-----
+
+Store user preference
++++++++++++++++++++++
+
+.. code-block:: python
+    from anvil_extras.storage import local_storage
+
+    class UserPreferences(UserPreferencesTemplate):
+        def __init__(self, **properties):
+            self.init_components(**properties)
+
+        def dark_mode_checkbox_change(self, **event_args):
+            local_storage['dark_mode'] = self.dark_mode_checkbox.checked
+
+
+Change the theme at startup
++++++++++++++++++++++++++++
+
+.. code-block:: python
+    ## inside a startup module
+    from anvil_extras.storage import local_storage
+
+    if local_storage.get('dark_mode') is not None:
+        # set the app theme to dark
+        ...
+
+
+
+local_storage and session_storage objects
+-----------------------------------------
+
+.. object:: session_storage
+    session_storage is a dictionary like object.
+
+.. object:: local_storage
+
+   local_storage is a dictionary like object.
+
+   .. describe:: list(local_storage)
+
+      Return a list of all the keys used in :object:`local_storage`.
+
+   .. describe:: len(local_storage)
+
+      Return the number of items in :object:`local_storage`.
+
+   .. describe:: local_storage[key]
+
+      Return the item of :object:`local_storage` with key *key*.  Raises a :exc:`KeyError` if *key* is
+      not in :object:`local_storage`. Raises a :exc:`TypeError` if *key* is not a string.
+
+   .. describe:: local_storage[key] = value
+
+      Set ``local_storage[key]`` to *value*. The *value* must be a json compatible object.
+
+   .. describe:: del local_storage[key]
+
+      Remove ``local_storage[key]`` from :object:`local_storage`. :exc:`KeyError` raised is NOT raised if the key is not in :object:`local_storage`.
+
+   .. describe:: key in local_storage
+
+      Return ``True`` if :object:`local_storage` has a key *key*, else ``False``.
+
+   .. describe:: iter(local_storage)
+
+      Return an iterator over the keys of the dictionary.  This is a shortcut
+      for ``iter(local_storage.keys())``.
+
+   .. method:: clear()
+
+      Remove all items from the dictionary.
+
+   .. method:: get(key[, default])
+
+      Return the value for *key* if *key* is in :object:`local_storage`, else *default*.
+      If *default* is not given, it defaults to ``None``, so that this method
+      never raises a :exc:`KeyError`.
+
+   .. method:: items()
+
+      Return a map iterator of :object:`local_storage`'s (``[key, value]`` pairs).
+
+   .. method:: keys()
+
+      Return a map iterator of the dictionary's keys.
+
+   .. method:: pop(key[, default])
+
+      If *key* is in :object:`local_storage`, remove it and return its value, else return
+      *default*.  If *default* is not given, it defaults to ``None``, so that this method
+      never raises a :exc:`KeyError`.
+
+   .. method:: put(key, value)
+
+      Equivalent to ``local_storage[key] = value``.
+
+   .. method:: update([other])
+
+      Update the :object:`local_storage` with the key/value pairs from *other*, overwriting
+      existing keys.  Return ``None``.
+
+      :meth:`update` accepts either a dictionary object or an iterable of
+      key/value pairs (as tuples or other iterables of length two).  If keyword
+      arguments are specified, :object:`local_storage` is then updated with those
+      key/value pairs: ``d.update(red=1, blue=2)``.
+
+   .. method:: values()
+
+      Return a map iterator of :object:`local_storage`'s values.

--- a/docs/guides/modules/storage.rst
+++ b/docs/guides/modules/storage.rst
@@ -1,5 +1,5 @@
 :mod:`storage` --- wrapper around window.Storage
-=====================================================
+================================================
 
 
 Introduction
@@ -45,11 +45,8 @@ Change the theme at startup
 
 
 
-local_storage and session_storage objects
------------------------------------------
-
-.. object:: session_storage
-    session_storage is a dictionary like object.
+local_storage
+-------------
 
 .. object:: local_storage
 


### PR DESCRIPTION
This module provides a python dictionary like wrapper around `window.sessionsStorage` and `window.localStorage`

the `local_storage` object allows for persistent data across sessions.
It can be used to create a simple todo app that works offline (for example)


