### PR TITLE
augment updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## New Features
+* `augment` - `add_event_handler()` method added. `original_event` passed as an `event_arg`.
+  https://github.com/anvilistas/anvil-extras/pull/109
+
 # v1.5.1 05-Jul-2021
 
 ## Bug Fixes


### PR DESCRIPTION
Anvil added the `add_event_handler` for components so I figured we should too.

There's no point in also adding the `remove_event_handler` since it would just do the exact same thing as the anvil.Component version.

We can also pass the `original_event` as an `event_arg`. 
I was about to answer [this forum post](https://anvil.works/forum/t/on-right-click-event/9125). But realised I wanted the original event to answer it fully. 


---

nb - I called it `original_event` because jQuery does but maybe `js_event` would be a better name...?



