### PR TITLE
Allow binding writeback on the Switch component

### DIFF
--- a/client_code/Switch/form_template.yaml
+++ b/client_code/Switch/form_template.yaml
@@ -1,6 +1,6 @@
 properties:
 - {name: checked, type: boolean, default_value: false, default_binding_prop: true,
-  important: true}
+  important: true, allow_binding_writeback: true}
 - {name: checked_color, type: color, default_value: null, group: appearance, important: false}
 - {name: enabled, type: boolean, default_value: true, group: interaction, important: true}
 - {name: foreground, type: color, default_value: null, group: appearance, important: false}


### PR DESCRIPTION
The Switch component doesn't currently support binding writeback, which is an inconvenience.

This PR adds this missing support that other components in the repo already have.