### PR TITLE
Support quill modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## New Features
+* Quill - dynamically add custom modules
+  https://github.com/anvilistas/anvil-extras/pull/117
 ## Bug Fixes
 * Autocomplete - can now be used inside an alert
   https://github.com/anvilistas/anvil-extras/pull/114

--- a/client_code/Quill/__init__.py
+++ b/client_code/Quill/__init__.py
@@ -21,7 +21,9 @@ _add_script('<link href="//cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet
 _add_script('<link href="//cdn.quilljs.com/1.3.6/quill.bubble.css" rel="stylesheet">')
 
 # <!-- Main Quill library -->
-_add_script('<script src="//cdn.quilljs.com/1.3.6/quill.min.js"></script>')
+if _window.get("Quill") is None:
+    # support including Quill in the native libraries for easier module imports
+    _add_script('<script src="//cdn.quilljs.com/1.3.6/quill.min.js"></script>')
 _Quill = _window.Quill
 
 
@@ -30,6 +32,7 @@ _defaults = {
     "content": None,
     "enabled": True,
     "height": 150,
+    "modules": None,
     "placeholder": None,
     "readonly": False,
     "spacing_above": "small",
@@ -106,7 +109,8 @@ class Quill(QuillTemplate):
         q = self._quill = _Quill(
             self._el,
             {
-                "modules": {"toolbar": self._props["toolbar"]},
+                "modules": {"toolbar": self._props["toolbar"]}
+                | (self._props["modules"] or {}),
                 "theme": self._props["theme"],
                 "placeholder": self._props["placeholder"],
                 "readOnly": self._props["readonly"],
@@ -188,6 +192,7 @@ class Quill(QuillTemplate):
     readonly = _quill_init_prop("readonly")
     theme = _quill_init_prop("theme")
     placeholder = _quill_init_prop("placeholder")
+    modules = _quill_init_prop("modules")
 
     #### ANVIL METHODS ####
     def get_markdown(self):

--- a/client_code/Quill/form_template.yaml
+++ b/client_code/Quill/form_template.yaml
@@ -11,8 +11,10 @@ properties:
 - {name: readonly, type: boolean, default_value: false, default_binding_prop: false,
   description: Similar to enabled but cannot be updated, group: interaction, important: false}
 - {name: toolbar, type: boolean, default_value: true, default_binding_prop: false,
-  description: This must be set in the constructor and cannot be updated, group: interaction,
-  important: true}
+  description: This can be set at runtime for different tooolbar configurations, important: false}
+- {name: modules, type: object, default_value: null, default_binding_prop: false,
+  description: This can be set at runtime and must include all modules. The toolbar can be set separately,
+  important: false}
 - {name: theme, type: string, default_value: snow, default_binding_prop: false, description: snow or bubble - check quill for the difference - cannot be updated once set,
   group: appearance, important: false}
 - {name: placeholder, type: string, default_value: '', default_binding_prop: false,

--- a/docs/guides/components/quill.rst
+++ b/docs/guides/components/quill.rst
@@ -27,6 +27,10 @@ Properties
 
     With auto_expand this becomes the starting height. Without auto_expand this becomes the fixed height.
 
+:modules: Object
+
+    Additional modules can be set at runtime. See Quill docs for examples. If a toolbar option is defined in modules this will override the toolbar property.
+
 :placeholder: String
 
     Placeholder when there is no text


### PR DESCRIPTION
close #87 

The code to implement #87 might include Quill and the imageResize module scripts in Native Libraries.
(It would need to include both since imageResize relies upon Quill existing)

Then in a form that uses a Quill component.

```python
class Form1(Form1Template):
  def __init__(self, **properties):
    # Set Form properties and Data Bindings.
    self.init_components(**properties)
    self.quill.modules = {"imageResize": {}}
```

@sebasm611 it's a bit late but how's this api for you?
