### PR TITLE
Add a reference to pre-commit to the contributing guide

### DIFF
--- a/docs/guides/contributing.rst
+++ b/docs/guides/contributing.rst
@@ -32,7 +32,12 @@ Use the `Black formatter <https://github.com/ambv/black>`_ to format all code an
 
 Add the licence text and copyright statement to the top of your code.
 
-Ensure that there is a line with the current version number towards the top of your code .
+Ensure that there is a line with the current version number towards the top of your code.
+
+This can be automated by using `pre-commit <https://pre-commit.com/>`_.
+To use ``pre-commit``, first install ``pre-commit`` with pip and then run ``pre-commit install`` inside your local ``anvil-extras`` repository.
+All commits thereafter will be adjusted according to the above ``anvil-extras`` python requirements.
+
 
 Documentation
 -------------


### PR DESCRIPTION
pre commit automates all the python checks and adjusts the code.
We should add a reference to this so that it's easier to contribute.