### PR TITLE
include routing.alert api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## New Features
 * Quill - dynamically add custom modules
   https://github.com/anvilistas/anvil-extras/pull/117
+* routing - routing.alert wraps anvil.alert to ensure dismissible alerts are closed on navigation
+  https://github.com/anvilistas/anvil-extras/pull/132
 ## Bug Fixes
 * Autocomplete - can now be used inside an alert
   https://github.com/anvilistas/anvil-extras/pull/114

--- a/client_code/routing/__init__.py
+++ b/client_code/routing/__init__.py
@@ -7,4 +7,5 @@
 
 __version__ = "1.5.2"
 
+from ._alert import alert, confirm
 from ._routing import *

--- a/client_code/routing/__init__.py
+++ b/client_code/routing/__init__.py
@@ -7,5 +7,4 @@
 
 __version__ = "1.5.2"
 
-from ._alert import alert, confirm
 from ._routing import *

--- a/client_code/routing/_alert.py
+++ b/client_code/routing/_alert.py
@@ -24,8 +24,8 @@ def handle_alert_unload() -> bool:
         return False
     elif not data.isShown:
         return False
-    elif data.options and data.options.backdrop is True:
-        # bootstrap alerts have a backdrop option of True when dismissible
+    elif data.options and data.options.backdrop != "static":
+        # bootstrap alerts have a backdrom of static when not dismissible
         alert_modal.modal("hide")
         return False
     _navigation.stopUnload()

--- a/client_code/routing/_alert.py
+++ b/client_code/routing/_alert.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright (c) 2021 The Anvil Extras project team members listed at
+# https://github.com/anvilistas/anvil-extras/graphs/contributors
+#
+# This software is published at https://github.com/anvilistas/anvil-extras
+
+from anvil import Label
+from anvil import alert as anvil_alert
+
+from . import _navigation
+
+
+class AlertInfo:
+    def __init__(self, active=False, dismissible=True, content=None):
+        self.update(active, dismissible, content)
+
+    def dismiss(self):
+        if self.content is not None:
+            self.content.raise_event("x-close-alert")
+
+    def update(self, active, dismissible=True, content=None):
+        self.active = active
+        self.dismissible = dismissible
+        self.content = content
+
+
+current_alert = AlertInfo()
+
+alert_btns = (("OK", True, "success"),)
+confirm_btns = (("No", False, "danger"), ("Yes", True, "success"))
+# defauult buttons in anvil included here for autocomplete
+# and because providing any value overrides anvil's default buttons
+
+
+def alert(
+    content, title="", buttons=alert_btns, large=False, dismissible=True, role=None
+):
+    """use in the same way as anvil.alert
+    If dismissible=True when a user navigates the alert will be closed
+    If dismissible=False navigating will be prevented
+    """
+    if isinstance(content, str):
+        content = Label(text=content)
+    current_alert.update(True, dismissible, content)
+    try:
+        return anvil_alert(
+            content,
+            title=title,
+            buttons=buttons,
+            large=large,
+            dismissible=dismissible,
+            role=role,
+        )
+    finally:
+        current_alert.update(False)
+
+
+def confirm(
+    content, title="", buttons=confirm_btns, large=False, dismissible=False, role=None
+):
+    return alert(content, title, buttons, large, dismissible, role)
+
+
+def handle_alert_unload() -> bool:
+    """
+    if there is an active alert which is not dismissible then navigation is prevented
+    return value indicates whether this function took control of the on_navigation
+    """
+    if not current_alert.active:
+        return False
+    elif current_alert.dismissible:
+        current_alert.dismiss()
+        return False
+    else:
+        _navigation.stopUnload()
+        return True

--- a/client_code/routing/_alert.py
+++ b/client_code/routing/_alert.py
@@ -7,102 +7,11 @@
 
 __version__ = "1.5.2"
 
-from anvil import Label
-from anvil import alert as anvil_alert
-from anvil import confirm as anvil_confirm
+from anvil.js.window import jQuery as _S
 
 from . import _navigation
 
-
-class AlertInfo:
-    def __init__(self, active=False, dismissible=True, content=None):
-        self.update(active, dismissible, content)
-
-    def dismiss(self) -> bool:
-        """returns a bool as to whether the alert was dismissed"""
-        if not self.active:
-            return True  # nothing to dismiss
-        if self.dismissible and self.content is not None:
-            self.content.raise_event("x-close-alert")
-            return True
-        return False
-
-    def update(self, active, dismissible=True, content=None):
-        self.active = active
-        self.dismissible = dismissible
-        self.content = content
-
-
-current_alert = AlertInfo()
-no_arg = object()
-# we use sentinel since the presence of an arg determines the behaviour of an alert
-alert_kws = ("title", "buttons", "large", "role")
-
-
-def wrap_alert(content, dismissible, is_confirm=False, **kws):
-    if isinstance(content, str):
-        content = Label(text=content)
-    current_alert.update(True, dismissible, content)
-    for key in alert_kws:
-        if kws.get(key) is no_arg:
-            del kws[key]
-            # remove sentinel values
-    try:
-        if is_confirm:
-            return anvil_confirm(content, dismissible=dismissible, **kws)
-        else:
-            return anvil_alert(content, dismissible=dismissible, **kws)
-    finally:
-        current_alert.update(False)
-
-
-# we keep the same order as defined in the api docs
-# use kws for future proofing additional anvil args
-def alert(
-    content,
-    *,
-    title=no_arg,
-    buttons=no_arg,
-    large=no_arg,
-    dismissible=True,
-    role=no_arg,
-    **kws
-):
-    """use in the same way as anvil.alert
-    If dismissible=True when a user navigates the alert will be closed
-    If dismissible=False navigating will be prevented
-    """
-    return wrap_alert(
-        content,
-        dismissible,
-        title=title,
-        buttons=buttons,
-        large=large,
-        role=role,
-        **kws
-    )
-
-
-def confirm(
-    content,
-    *,
-    title=no_arg,
-    buttons=no_arg,
-    large=no_arg,
-    dismissible=False,
-    role=no_arg,
-    **kws
-):
-    return wrap_alert(
-        content,
-        dismissible,
-        is_confirm=True,
-        title=title,
-        buttons=buttons,
-        large=large,
-        role=role,
-        **kws
-    )
+modal = _S("#alert-modal")
 
 
 def handle_alert_unload() -> bool:
@@ -110,7 +19,13 @@ def handle_alert_unload() -> bool:
     if there is an active alert which is not dismissible then navigation is prevented
     return value indicates whether this function took control of the on_navigation
     """
-    if current_alert.dismiss():
+    data = modal.data("bs.modal")
+    if data is None:
+        return False
+    elif not data.isShown:
+        return False
+    elif data.options and data.options.backdrop is True:
+        # bootstrap alerts have a backdrop option of True when dismissible
         return False
     _navigation.stopUnload()
     return True

--- a/client_code/routing/_alert.py
+++ b/client_code/routing/_alert.py
@@ -5,6 +5,8 @@
 #
 # This software is published at https://github.com/anvilistas/anvil-extras
 
+__version__ = "1.5.2"
+
 from anvil import Label
 from anvil import alert as anvil_alert
 

--- a/client_code/routing/_alert.py
+++ b/client_code/routing/_alert.py
@@ -9,6 +9,7 @@ __version__ = "1.5.2"
 
 from anvil import Label
 from anvil import alert as anvil_alert
+from anvil import confirm as anvil_confirm
 
 from . import _navigation
 
@@ -17,9 +18,14 @@ class AlertInfo:
     def __init__(self, active=False, dismissible=True, content=None):
         self.update(active, dismissible, content)
 
-    def dismiss(self):
-        if self.content is not None:
+    def dismiss(self) -> bool:
+        """returns a bool as to whether the alert was dismissed"""
+        if not self.active:
+            return True  # nothing to dismiss
+        if self.dismissible and self.content is not None:
             self.content.raise_event("x-close-alert")
+            return True
+        return False
 
     def update(self, active, dismissible=True, content=None):
         self.active = active
@@ -28,40 +34,75 @@ class AlertInfo:
 
 
 current_alert = AlertInfo()
-
-alert_btns = (("OK", True, "success"),)
-confirm_btns = (("No", False, "danger"), ("Yes", True, "success"))
-# defauult buttons in anvil included here for autocomplete
-# and because providing any value overrides anvil's default buttons
+no_arg = object()
+# we use sentinel since the presence of an arg determines the behaviour of an alert
+alert_kws = ("title", "buttons", "large", "role")
 
 
+def wrap_alert(content, dismissible, is_confirm=False, **kws):
+    if isinstance(content, str):
+        content = Label(text=content)
+    current_alert.update(True, dismissible, content)
+    for key in alert_kws:
+        if kws.get(key) is no_arg:
+            del kws[key]
+            # remove sentinel values
+    try:
+        if is_confirm:
+            return anvil_confirm(content, dismissible=dismissible, **kws)
+        else:
+            return anvil_alert(content, dismissible=dismissible, **kws)
+    finally:
+        current_alert.update(False)
+
+
+# we keep the same order as defined in the api docs
+# use kws for future proofing additional anvil args
 def alert(
-    content, title="", buttons=alert_btns, large=False, dismissible=True, role=None
+    content,
+    *,
+    title=no_arg,
+    buttons=no_arg,
+    large=no_arg,
+    dismissible=True,
+    role=no_arg,
+    **kws
 ):
     """use in the same way as anvil.alert
     If dismissible=True when a user navigates the alert will be closed
     If dismissible=False navigating will be prevented
     """
-    if isinstance(content, str):
-        content = Label(text=content)
-    current_alert.update(True, dismissible, content)
-    try:
-        return anvil_alert(
-            content,
-            title=title,
-            buttons=buttons,
-            large=large,
-            dismissible=dismissible,
-            role=role,
-        )
-    finally:
-        current_alert.update(False)
+    return wrap_alert(
+        content,
+        dismissible,
+        title=title,
+        buttons=buttons,
+        large=large,
+        role=role,
+        **kws
+    )
 
 
 def confirm(
-    content, title="", buttons=confirm_btns, large=False, dismissible=False, role=None
+    content,
+    *,
+    title=no_arg,
+    buttons=no_arg,
+    large=no_arg,
+    dismissible=False,
+    role=no_arg,
+    **kws
 ):
-    return alert(content, title, buttons, large, dismissible, role)
+    return wrap_alert(
+        content,
+        dismissible,
+        is_confirm=True,
+        title=title,
+        buttons=buttons,
+        large=large,
+        role=role,
+        **kws
+    )
 
 
 def handle_alert_unload() -> bool:
@@ -69,11 +110,7 @@ def handle_alert_unload() -> bool:
     if there is an active alert which is not dismissible then navigation is prevented
     return value indicates whether this function took control of the on_navigation
     """
-    if not current_alert.active:
+    if current_alert.dismiss():
         return False
-    elif current_alert.dismissible:
-        current_alert.dismiss()
-        return False
-    else:
-        _navigation.stopUnload()
-        return True
+    _navigation.stopUnload()
+    return True

--- a/client_code/routing/_alert.py
+++ b/client_code/routing/_alert.py
@@ -11,7 +11,7 @@ from anvil.js.window import jQuery as _S
 
 from . import _navigation
 
-modal = _S("#alert-modal")
+alert_modal = _S("#alert-modal")
 
 
 def handle_alert_unload() -> bool:
@@ -19,13 +19,14 @@ def handle_alert_unload() -> bool:
     if there is an active alert which is not dismissible then navigation is prevented
     return value indicates whether this function took control of the on_navigation
     """
-    data = modal.data("bs.modal")
+    data = alert_modal.data("bs.modal")
     if data is None:
         return False
     elif not data.isShown:
         return False
     elif data.options and data.options.backdrop is True:
         # bootstrap alerts have a backdrop option of True when dismissible
+        alert_modal.modal("hide")
         return False
     _navigation.stopUnload()
     return True

--- a/client_code/routing/_logging.py
+++ b/client_code/routing/_logging.py
@@ -9,15 +9,17 @@ __version__ = "1.5.2"
 
 
 class Logger:
-    def __init__(self, debug, msg=""):
+    def __init__(self, debug, msg="", save=False):
         self.debug = debug
         self.msg = msg
+        self.save = save
         self._log = [(msg,)]
 
     def print(self, *args, **kwargs):
         if self.debug:
             print(self.msg, *args, **kwargs) if self.msg else print(*args, **kwargs)
-        self._log.append(args)
+        if self.save:
+            self._log.append(args)
 
     def show_log(self):
         log_rows = [" ".join(str(arg) for arg in args) for args in self._log]

--- a/client_code/routing/_routing.py
+++ b/client_code/routing/_routing.py
@@ -13,6 +13,7 @@ from collections import namedtuple as _namedtuple
 import anvil as _anvil
 
 from . import _navigation
+from ._alert import handle_alert_unload as _handle_alert_unload
 from ._logging import logger
 
 # to print route logging messages set routing.logger.debug = True above your main_router form
@@ -86,6 +87,11 @@ def main_router(Cls):
                     "**WARNING**  \nurl_hash redirected too many times without a form load, getting out\ntry setting redirect=False"
                 )
                 return  # could change this to a raise
+
+            if _handle_alert_unload():
+                logger.print("unload prevented by active alert")
+                return
+
             _on_navigation_stack_depth += 1
 
             if getattr(_current_form, "before_unload", None):
@@ -106,8 +112,6 @@ def main_router(Cls):
                         _navigation.stopUnload()
                         _on_navigation_stack_depth -= 1
                         return  # this will stop the navigation
-                except Exception as e:
-                    raise e
                 finally:
                     _navigation.setUnloadPopStateBehaviour(False)
 


### PR DESCRIPTION
close #131 

wrapper around anvil alerts.
If an alert is dismissible then the alert will be closed on navigation
if an alert is not dismissible then navigation will be halted

---

Also included in this pr - logger doesn't save logs by default - i figure this feature is not really used and seems unnecessary to create an ever growing list of logs.

---

I'll document this as part #40 

@stenci might want to take a look at the api/code

