### PR TITLE
Use localforage to create a wrapper around indexed_db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,13 @@
 ## New Features
 * Quill - dynamically add custom modules
   https://github.com/anvilistas/anvil-extras/pull/117
-* routing - routing.alert wraps anvil.alert to ensure dismissible alerts are closed on navigation
+* routing - adjusts the behaviour of anvil.alert to ensure dismissible alerts are closed on navigation. And navigation prevented for non-dismissible alerts.
   https://github.com/anvilistas/anvil-extras/pull/132
+* `storage.indexed_db` - Now supports the browser's `IndexedDB` with a dictionary like api
+  https://github.com/anvilistas/anvil-extras/pull/135
+* storage - additional store objects can be created inside the browsers `localStorage` or `IndexedDB`. e.g. `todo_store = indexed_db.get_store('todos')`
+  Each store object behaves like a dictionary object.
+  https://github.com/anvilistas/anvil-extras/pull/135
 ## Bug Fixes
 * Autocomplete - can now be used inside an alert
   https://github.com/anvilistas/anvil-extras/pull/114
@@ -14,6 +19,10 @@
   https://github.com/anvilistas/anvil-extras/pull/125
 * PageBreak - fix margin_top property and make it optional
   https://github.com/anvilistas/anvil-extras/pull/137
+
+## Deprecated
+* storage.session_storage was deprecated. Use local_storage instead
+  https://github.com/anvilistas/anvil-extras/pull/135
 
 ## Updates
 * Slider Component - bump javascript dependency and refactor. No changes to the component's public API.

--- a/client_code/storage.py
+++ b/client_code/storage.py
@@ -23,9 +23,17 @@ class StorageWrapper:
         self._name = name
 
     def is_supported(self):
+        """check if the store object is available and accessible."""
         # in some browsers localStorageWrapper might not be available
-        # we don't throw the error until we try to access the store
-        return self._store.supports(self._driver)
+        if not self._store.supports(self._driver):
+            # we cn't rely on this method - it's just for browser support
+            return False
+        try:
+            self._store.length()
+            # call a method in the store to activate the store
+            return True
+        except Exception:
+            return False
 
     def __getitem__(self, key):
         if key in self._store.keys():

--- a/client_code/storage.py
+++ b/client_code/storage.py
@@ -97,9 +97,11 @@ class StorageWrapper:
         """returns the values for local storage as an iterator"""
         return (_deserialize(self._store.getItem(key)) for key in self._store.keys())
 
-    def put(self, key, value):
+    def store(self, key, value):
         """put a key value pair into local storage"""
         self[key] = value
+
+    put = store  # backward compatibility
 
     def get(self, key, default=None):
         """get a value from local storage, returns the default value if the key is not in local storage"""

--- a/docs/guides/modules/storage.rst
+++ b/docs/guides/modules/storage.rst
@@ -11,6 +11,9 @@ convenient dictionary like wrappers around the native browser objects.
 The :attr:`local_storage` and :attr:`indexed_db` objects can store data that persists accross browser sessions and are also available offline.
 It could be used to create an entirely offline todo app, or to store data across sessions.
 
+Note that when working in the IDE the app is running in an IFrame and the ``storage`` objects may not be available. This can be fixed by changing your browser settings.
+Turning the shields down in Brave or making sure not to block third party cookies in Chrome should fix this.
+
 
 Which to chose?
 +++++++++++++++
@@ -63,7 +66,7 @@ API
 
    .. describe:: get_store(name)
 
-      Get or create a ``storage`` object. e.g. ``todo_store = indexed_db.get_store('todos')``. This will create a new storeage object inside the browser's ``IndexedDB``.
+      Get or create a ``storage`` object. e.g. ``todo_store = indexed_db.get_store('todos')``. This will create a new storage object inside the browser's ``IndexedDB``.
       The :attr:`indexed_db` object is equivalent to ``indexed_db.get_store('default')``. To explore this further, open up devtools and find ``IndexedDB`` in the Application tab.
 
    .. describe:: list(store)
@@ -81,7 +84,7 @@ API
 
    .. describe:: store[key] = value
 
-      Set ``store[key]`` to *value*. If the value is not a JSONable data type it may be stored correctly. e.g. a ``datetime`` object.
+      Set ``store[key]`` to *value*. If the value is not a JSONable data type it may be stored incorrectly. e.g. a ``datetime`` object.
       If storing ``bytes`` objects it is best to use the :attr:`indexed_db` store.
 
    .. describe:: del store[key]

--- a/docs/guides/modules/storage.rst
+++ b/docs/guides/modules/storage.rst
@@ -124,7 +124,7 @@ API
       *default*.  If *default* is not given, it defaults to ``None``, so that this method
       never raises a :exc:`KeyError`.
 
-   .. method:: put(key, value)
+   .. method:: store(key, value)
 
       Equivalent to ``store[key] = value``.
 

--- a/docs/guides/modules/storage.rst
+++ b/docs/guides/modules/storage.rst
@@ -60,7 +60,7 @@ API
 
    both :attr:`indexed_db` and :attr:`local_storage` are instances of a dictionary like :class:`StorageWrapper` class.
 
-   .. describe:: is_supported()
+   .. describe:: is_available()
 
       Check if the storage object is supported. Returns a ``boolean``.
 

--- a/docs/guides/modules/storage.rst
+++ b/docs/guides/modules/storage.rst
@@ -64,10 +64,10 @@ API
 
       Check if the storage object is supported. Returns a ``boolean``.
 
-   .. describe:: get_store(name)
+   .. describe:: create_store(name)
 
-      Get or create a ``storage`` object. e.g. ``todo_store = indexed_db.get_store('todos')``. This will create a new storage object inside the browser's ``IndexedDB``.
-      The :attr:`indexed_db` object is equivalent to ``indexed_db.get_store('default')``. To explore this further, open up devtools and find ``IndexedDB`` in the Application tab.
+      Get or create a ``storage`` object. e.g. ``todo_store = indexed_db.create_store('todos')``. This will create a new storage object inside the browser's ``IndexedDB``.
+      The :attr:`indexed_db` object is equivalent to ``indexed_db.create_store('default')``. To explore this further, open up devtools and find ``IndexedDB`` in the Application tab.
 
    .. describe:: list(store)
 

--- a/docs/guides/modules/storage.rst
+++ b/docs/guides/modules/storage.rst
@@ -3,16 +3,20 @@ Storage
 
 Introduction
 ------------
-Browsers have a ``localStorage`` object that can store data between browser sessions
+Browsers have various ways to store data. ``localStorage`` and ``indexedDB`` are two such storage mechanisms that are particularly useful for storing data offline.
 
-The anvil_extras :mod:`storage` module provides :const:`local_storage` object, which is a
-convenient dictionary like wrapper around the native browser ``localStorage`` object.
+The anvil_extras :mod:`storage` module provides both a :attr:`local_storage` object and a :attr:`indexed_db` object, which are
+convenient dictionary like wrappers around the native browser objects.
 
-The :attr:`local_storage` object can store data that persists accross browser sessions and is also available offline.
-It could be used to create an entirely offline todo app, or to store simple data across sessions.
+The :attr:`local_storage` and :attr:`indexed_db` objects can store data that persists accross browser sessions and are also available offline.
+It could be used to create an entirely offline todo app, or to store data across sessions.
 
-(Browsers also have a ``sessionStorage`` object, and an equivalent :const:`session_storage`
-object is also available in the :mod:`storage` module.)
+
+Which to chose?
++++++++++++++++
+If you have small amounts of data which can be converted to JSON then use the :attr:`local_storage` object.
+If you have more data which can be converted to JSON (and also ``bytes`` objects) - use :attr:`indexed_db`.
+
 
 Usage
 -----
@@ -49,39 +53,49 @@ Change the theme at startup
 API
 ---
 
-.. object:: local_storage
+.. class:: StorageWrapper()
 
-   local_storage is a dictionary like object.
+   both :attr:`indexed_db` and :attr:`local_storage` are instances of a dictionary like :class:`StorageWrapper` class.
 
-   .. describe:: list(local_storage)
+   .. describe:: is_supported()
 
-      Return a list of all the keys used in :attr:`local_storage`.
+      Check if the storage object is supported. Returns a ``boolean``.
 
-   .. describe:: len(local_storage)
+   .. describe:: get_store(name)
 
-      Return the number of items in :attr:`local_storage`.
+      Get or create a ``storage`` object. e.g. ``todo_store = indexed_db.get_store('todos')``. This will create a new storeage object inside the browser's ``IndexedDB``.
+      The :attr:`indexed_db` object is equivalent to ``indexed_db.get_store('default')``. To explore this further, open up devtools and find ``IndexedDB`` in the Application tab.
 
-   .. describe:: local_storage[key]
+   .. describe:: list(store)
 
-      Return the item of :attr:`local_storage` with key *key*.  Raises a :exc:`KeyError` if *key* is
-      not in :attr:`local_storage`. Raises a :exc:`TypeError` if *key* is not a string.
+      Return a list of all the keys used in the *store*.
 
-   .. describe:: local_storage[key] = value
+   .. describe:: len(store)
 
-      Set ``local_storage[key]`` to *value*. The *value* must be a json compatible object.
+      Return the number of items in *store*.
 
-   .. describe:: del local_storage[key]
+   .. describe:: store[key]
 
-      Remove ``local_storage[key]`` from :attr:`local_storage`.
+      Return the item of *store* with key *key*.  Raises a :exc:`KeyError` if *key* is
+      not in *store*. Raises a :exc:`TypeError` if *key* is not a string.
 
-   .. describe:: key in local_storage
+   .. describe:: store[key] = value
 
-      Return ``True`` if :attr:`local_storage` has a key *key*, else ``False``.
+      Set ``store[key]`` to *value*. If the value is not a JSONable data type it may be stored correctly. e.g. a ``datetime`` object.
+      If storing ``bytes`` objects it is best to use the :attr:`indexed_db` store.
 
-   .. describe:: iter(local_storage)
+   .. describe:: del store[key]
 
-      Return an iterator over the keys of the dictionary.  This is a shortcut
-      for ``iter(local_storage.keys())``.
+      Remove ``store[key]`` from *store*.
+
+   .. describe:: key in store
+
+      Return ``True`` if *store* has a key *key*, else ``False``.
+
+   .. describe:: iter(store)
+
+      Return an iterator over the keys of the *store*.  This is a shortcut
+      for ``iter(store.keys())``.
 
    .. method:: clear()
 
@@ -89,13 +103,13 @@ API
 
    .. method:: get(key[, default])
 
-      Return the value for *key* if *key* is in :attr:`local_storage`, else *default*.
+      Return the value for *key* if *key* is in *store*, else *default*.
       If *default* is not given, it defaults to ``None``, so that this method
       never raises a :exc:`KeyError`.
 
    .. method:: items()
 
-      Return a map iterator of :attr:`local_storage`'s ``(key, value)`` pairs.
+      Return a map iterator of *store*'s ``(key, value)`` pairs.
 
    .. method:: keys()
 
@@ -103,24 +117,24 @@ API
 
    .. method:: pop(key[, default])
 
-      If *key* is in :attr:`local_storage`, remove it and return its value, else return
+      If *key* is in *store*, remove it and return its value, else return
       *default*.  If *default* is not given, it defaults to ``None``, so that this method
       never raises a :exc:`KeyError`.
 
    .. method:: put(key, value)
 
-      Equivalent to ``local_storage[key] = value``.
+      Equivalent to ``store[key] = value``.
 
    .. method:: update([other])
 
-      Update the :attr:`local_storage` with the key/value pairs from *other*, overwriting
+      Update the *store* with the key/value pairs from *other*, overwriting
       existing keys.  Return ``None``.
 
       :meth:`update` accepts either a dictionary object or an iterable of
       key/value pairs (as tuples or other iterables of length two).  If keyword
-      arguments are specified, :attr:`local_storage` is then updated with those
-      key/value pairs: ``local_storage.update(red=1, blue=2)``.
+      arguments are specified, *store* is then updated with those
+      key/value pairs: ``store.update(red=1, blue=2)``.
 
    .. method:: values()
 
-      Return a map iterator of :attr:`local_storage`'s values.
+      Return a map iterator of *store*'s values.


### PR DESCRIPTION
close #130, close #106, close #129 

I use `localforage` to wrap `localStorage` and `indexedDB`.

This pr deprecates `session_storage` - it's not particularly useful anyway.
It's deprecated because localforage doesn't have a wrapper for it.


It adds a nice api for creating a new store
This is like creating a new dictionary object.
```python
from anvi_extras.storage import indexed_db as db
todo_store = db.get_store('todos')
```

It also adds an `is_supported()` method which returns a `boolean`.
You don't get an error on import anymore.
But if you try to use the store in anyway, and it's not supported you do get 
`ExternalError: Error: No available storage method found.`


compromises and hacks:
- the repr can't expose the internals since localforage is very asyncronous and reprs can't be asyncronous in skulpt
- I had to hack the return values to convert proxy objects back to dictionaries
- I used a Promise hack for removing an item because of asyncronous code (del doesn't like being asyncronous either)

