### PR TITLE
Add border property to PageBreak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
   https://github.com/anvilistas/anvil-extras/pull/116
 * Popover - documentation added and clone link updated. The example now imports `anvil_extras`
   https://github.com/anvilistas/anvil-extras/pull/121
+* PageBreak - `border` property and documentation added. Fixed illegal HTML
+  https://github.com/anvilistas/anvil-extras/pull/139
 
 # v1.5.2 23-Aug-2021
 

--- a/client_code/PageBreak/__init__.py
+++ b/client_code/PageBreak/__init__.py
@@ -15,8 +15,11 @@ __version__ = "1.5.2"
 class PageBreak(PageBreakTemplate):
     def __init__(self, margin_top=0, border="1px solid grey", **properties):
         self.margin_node = _S(anvil.js.get_dom_node(self)).find(".margin-element")
+        self.break_container = _S(anvil.js.get_dom_node(self)).find(".break-container")
+
         self.margin_top = margin_top
         self.border = border
+
         self.init_components(**properties)
 
     @property
@@ -34,5 +37,5 @@ class PageBreak(PageBreakTemplate):
 
     @border.setter
     def border(self, value):
-        self.margin_node.css("border", value)
+        self.break_container.css("border", value)
         self._border = value

--- a/client_code/PageBreak/__init__.py
+++ b/client_code/PageBreak/__init__.py
@@ -13,9 +13,10 @@ __version__ = "1.5.2"
 
 
 class PageBreak(PageBreakTemplate):
-    def __init__(self, margin_top=0, **properties):
+    def __init__(self, margin_top=0, border="1px solid grey", **properties):
         self.margin_node = _S(anvil.js.get_dom_node(self)).find(".margin-element")
         self.margin_top = margin_top
+        self.border = border
         self.init_components(**properties)
 
     @property
@@ -26,3 +27,12 @@ class PageBreak(PageBreakTemplate):
     def margin_top(self, value):
         self.margin_node.css("margin-top", value)
         self._margin_top = value
+
+    @property
+    def border(self):
+        return self._border
+
+    @border.setter
+    def border(self, value):
+        self.margin_node.css("border", value)
+        self._border = value

--- a/client_code/PageBreak/__init__.py
+++ b/client_code/PageBreak/__init__.py
@@ -14,8 +14,9 @@ __version__ = "1.5.2"
 
 class PageBreak(PageBreakTemplate):
     def __init__(self, margin_top=0, border="1px solid grey", **properties):
-        self.margin_node = _S(anvil.js.get_dom_node(self)).find(".margin-element")
-        self.break_container = _S(anvil.js.get_dom_node(self)).find(".break-container")
+        dom_node = _S(anvil.js.get_dom_node(self))
+        self.margin_node = dom_node.find(".margin-element")
+        self.break_container = dom_node.find(".break-container")
 
         self.margin_top = margin_top
         self.border = border

--- a/client_code/PageBreak/form_template.yaml
+++ b/client_code/PageBreak/form_template.yaml
@@ -3,10 +3,10 @@ container:
   properties: {tooltip: '', background: '', foreground: '', border: '', visible: true,
     role: null, html: "<!--\nBased on the snippet at https://anvil.works/forum/t/plots-in-pdf-being-divided-between-two-pages/7774/5\n\
       -->\n<div class=\"break-container\" style=\"overflow: hidden;\">\n  <div style=\"\
-      page-break-after:always;\"/>\n  <div class=\"margin-element\" style=\"margin-top:\
-      \ 0px;\"/>\n</div>\n\n<style>\n  .break-container {\n    border: 1px solid grey;\n\
-      \  }\n  @media print {\n    .break-container {\n      border: none !important;\n\
-      \    }\n  }\n</style>"}
+      page-break-after:always;\"></div>\n  <div class=\"margin-element\" style=\"\
+      margin-top: 0px;\"></div>\n</div>\n\n<style>\n  .break-container {\n    border:\
+      \ 1px solid grey;\n  }\n  @media print {\n    .break-container {\n      border:\
+      \ none !important;\n    }\n  }\n</style>\n"}
 components: []
 is_package: true
 custom_component: true

--- a/client_code/PageBreak/form_template.yaml
+++ b/client_code/PageBreak/form_template.yaml
@@ -4,11 +4,11 @@ container:
     role: null, html: "<!--\nBased on the snippet at https://anvil.works/forum/t/plots-in-pdf-being-divided-between-two-pages/7774/5\n\
       -->\n<div class=\"break-container\" style=\"overflow: hidden;\">\n  <div style=\"\
       page-break-after:always;\"/>\n  <div class=\"margin-element\" style=\"margin-top:\
-      \ 0px;\"/>\n</div>\n\n<style>\n  .break-container {\n    border: 1px solid grey;\n\
-      \  }\n  @media print {\n    .break-container {\n      border: none;\n    }\n\
-      \  }\n</style>"}
+      \ 0px;\"/>\n</div>\n\n<style>\n  @media print {\n    .break-container {\n  \
+      \    border: none;\n    }\n  }\n</style>"}
 components: []
 is_package: true
 custom_component: true
 properties:
 - {name: margin_top, type: number, default_value: 0, default_binding_prop: true, description: Use to adjust whitespace at the top of each page in the generated pdf. This is an optional property and defaults to 0. Can be positive or negative. Negative numbers will reduce whitespace in the generated pdf.}
+- {name: border, type: string, default_value: 1px solid gray, description: Use to set the style in the form. Useful when the PDF has many grey horizontal lines and the default border style would be confusing. Has no effect on the printed PDF.}

--- a/client_code/PageBreak/form_template.yaml
+++ b/client_code/PageBreak/form_template.yaml
@@ -4,8 +4,9 @@ container:
     role: null, html: "<!--\nBased on the snippet at https://anvil.works/forum/t/plots-in-pdf-being-divided-between-two-pages/7774/5\n\
       -->\n<div class=\"break-container\" style=\"overflow: hidden;\">\n  <div style=\"\
       page-break-after:always;\"/>\n  <div class=\"margin-element\" style=\"margin-top:\
-      \ 0px;\"/>\n</div>\n\n<style>\n  @media print {\n    .break-container {\n  \
-      \    border: none;\n    }\n  }\n</style>"}
+      \ 0px;\"/>\n</div>\n\n<style>\n  .break-container {\n    border: 1px solid grey;\n\
+      \  }\n  @media print {\n    .break-container {\n      border: none !important;\n\
+      \    }\n  }\n</style>"}
 components: []
 is_package: true
 custom_component: true

--- a/docs/guides/components/page_break.rst
+++ b/docs/guides/components/page_break.rst
@@ -2,11 +2,11 @@ PageBreak
 =========
 For use in forms which are rendered to PDF to indicate that a page break is required.
 
-The optional ``margin_top`` property  allows to change the amount of white space at the top of the page.
+The optional ``margin_top`` property  changes the amount of white space at the top of the page.
 You can set the ``margin_top`` property to a positive/negative number to adjust the whitespace.
 Most of the time this is unnecessary. This won't have any effect on the designer, only the generated PDF.
 
-The optional ``border`` property allows to define the style of the component in the IDE.
+The optional ``border`` property defines the style of the component in the IDE.
 The value of the property affects how a ``PageBreak`` component looks in the browser during the execution.
 It has no effect in the generated PDF, where the component is never visible or in the IDE, where the component
 is always ``"1px solid grey"``.

--- a/docs/guides/components/page_break.rst
+++ b/docs/guides/components/page_break.rst
@@ -2,6 +2,21 @@ PageBreak
 =========
 For use in forms which are rendered to PDF to indicate that a page break is required.
 
-The ``margin_top`` property is optional. In the generated pdf you may want more or less white space at the top of the page.
+The optional ``margin_top`` property  allows to change the amount of white space at the top of the page.
 You can set the ``margin_top`` property to a positive/negative number to adjust the whitespace.
-Most of the time this is unnecessary. This won't have any effect on the designer only the generated pdf.
+Most of the time this is unnecessary. This won't have any effect on the designer, only the generated PDF.
+
+The optional ``border`` property allows to define the style of the component in the IDE.
+The value of the property affects how a ``PageBreak`` component looks in the browser during the execution.
+It has no effect in the generated PDF, where the component is never visible or in the IDE, where the component
+is always ``"1px solid grey"``.
+
+It is possible to change the default style for all the ``PageBreak``\ s in the app by adding the following code to ``theme.css``:
+
+.. code-block:: css
+
+    .break-container {
+        border: 2px dashed red !important;
+    }
+
+Using this technique rather than the ``border`` property affects how the component looks both in the IDE and at runtime.


### PR DESCRIPTION
Sometimes the PDF contains horizontal grey lines, so the PageBreak lines get confused with the ones that are part of the PDF.

This new `border` property allows to change the default style to something different form the rest of the PDF. It has no effect on the generated PDF.

In one of my PDFs I'm using:
```python
self.add_component(TruckPDF(self.truck))
for crate in self.truck.crates:
  self.add_component(PageBreak(border='1px dashed red'))
  self.add_component(CratePDF(crate))
```

close #142 