### PR TITLE
use anvil.js.await_promise in a couple of places

### DIFF
--- a/client_code/storage.py
+++ b/client_code/storage.py
@@ -5,6 +5,7 @@
 #
 # This software is published at https://github.com/anvilistas/anvil-extras
 
+import anvil.js
 from anvil.js import window as _window
 
 from utils._component_helpers import _add_script
@@ -189,13 +190,13 @@ def _fail_access(fn):
 
 
 def _fail_db(*args):
-    def check__(res, rej):
-        req = _window.get("indexedDB").open("anvil_extras")
+    def check_db(res, rej):
+        req = _window.indexedDB.open("anvil_extras")
         req.onerror = lambda e: rej(req.error.toString())
         req.onsuccess = lambda r: res(None)
 
     # this is asyncronous so use the Promise api
-    _window.Function("callback", "return new Promise(callback)")(check__)
+    anvil.js.await_promise(_window.Promise(check_db))
 
 
 def _fail_ls(*args):

--- a/client_code/utils/_component_helpers.py
+++ b/client_code/utils/_component_helpers.py
@@ -6,14 +6,15 @@
 # This software is published at https://github.com/anvilistas/anvil-extras
 import random
 
+import anvil.js
 from anvil import app as _app
 from anvil.js import get_dom_node as _get_dom_node
+from anvil.js.window import Promise as _Promise
 from anvil.js.window import document as _document
 from anvil.js.window import jQuery as _S
 
 __version__ = "1.5.2"
 
-_loaded = False
 _characters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 
@@ -37,20 +38,6 @@ def _get_dom_node_id(component):
     return node.id
 
 
-def _onload(e):
-    global _loaded
-    _loaded = True
-
-
-def _wait_for_load(interval=0.005):
-    global _loaded
-    while not _loaded:
-        from time import sleep
-
-        sleep(interval)
-    _loaded = False
-
-
 def _add_script(s):
     dummy = _S(s)[0]  # let jquery pass the tag
     s = _document.createElement(dummy.tagName)
@@ -60,8 +47,13 @@ def _add_script(s):
     _document.head.appendChild(s)
     if not s.get("src"):
         return
-    s.onload = s.onerror = _onload  # ignore errors
-    _wait_for_load()
+
+    def _wait_for_load(res, rej):
+        s.onload = res
+        s.onerror = rej
+
+    p = _Promise(_wait_for_load)
+    anvil.js.await_promise(p)
 
 
 def _spacing_property(a_b):


### PR DESCRIPTION
Another sneaky anvil update.

I've identified a couple of places in the code base where we can use it.

from the [anvil docs](https://anvil.works/docs/client/javascript/accessing-javascript#calling-asynchronous-javascript-apis):

> If you obtain a Promise object by some other route (for example, as the attribute of an object, or by constructing it directly), you can block until it resolves by calling `anvil.js.await_promise(js_promise)`. This will return the resolved value of the Promise, or raise an exception if it rejects.