### PR TITLE
Popover transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
   https://github.com/anvilistas/anvil-extras/pull/137
 * PageBreak and Multi-select - fix illegal HTML
   https://github.com/anvilistas/anvil-extras/pull/139
+* Popover - remove the requirement for delays in show/hide/destroy transitions
+  https://github.com/anvilistas/anvil-extras/pull/146
 
 
 ## Deprecated

--- a/client_code/popover.py
+++ b/client_code/popover.py
@@ -110,14 +110,19 @@ def popover(
 
     if trigger == "stickyhover":
         trigger = "manual"
+        from time import sleep
+
+        def sticky_leave(e):
+            sleep(0.1)  # small delay to allow the mouse to move to the element
+            if not _S("[popover_id={}]:hover".format(popper_id)):
+                pop(self, "hide")
+
         popper_element.on(
             "mouseenter",
             lambda e: None if pop(self, "is_visible") else pop(self, "show"),
         ).on(
             "mouseleave",
-            lambda e: None
-            if _S("[popover_id={}]:hover".format(popper_id))
-            else pop(self, "hide"),
+            sticky_leave,
         )
         _set_sticky_hover()
         _sticky_popovers.add(popper_id)


### PR DESCRIPTION
close #145 

This adds a feature to wait for a show/hide transition to complete - so that developers don't need to add sleeps when doing advanced things with popovers.

bootstrap provides 4 popover events `show`, `shown`, `hide`, `hidden`
race conditions occur when we've started a hide but we're in the middle of a show and haven't yet reached shown.

There isn't really a way to link the events and wait for one to complete.
So we create a javascript promise that starts when the show starts and resolves when we're shown.
This way we can wait for the transition to complete before attempting a new transition.

I've tried it on the clone for https://anvil.works/forum/t/popovers-implementing-triggering-a-popover-on-the-same-element/9799 and it works very nicely.

I add a private `_in_transition` to the anvil component.
I think that's ok.

---

While i'm here I also make a small fix to stickyhover - adding a delay so that the mouse can get to the popover in a more timely fashion before it disappears.
