### PR TITLE
Popover refactor

### DIFF
--- a/client_code/popover.py
+++ b/client_code/popover.py
@@ -13,11 +13,7 @@
 # https://getbootstrap.com/docs/3.4/javascript/#popovers
 #
 
-from random import choice as _random_choice
-from string import ascii_letters as _letters
-
 import anvil as _anvil
-import anvil.js
 from anvil.js.window import document as _document
 from anvil.js.window import jQuery as _S
 from anvil.js.window import window as _window
@@ -55,89 +51,36 @@ def popover(
         component = content
         content = _anvil.js.get_dom_node(content)  # get the dom node
     else:
-        raise TypeError(
-            "content to a popover should be either a str or anvil Component, not {}".format(
-                type(content).__name__
-            )
-        )
+        type_name = type(content).__name__
+        msg = "content to a popover should be either a str or anvil Component, not {}"
+        raise TypeError(msg.format(type_name))
 
+    if getattr(self, "_in_transition", None):
+        # we've been created and we're part way through a transition
+        # hopefully the transition is destroy!
+        _anvil.js.await_promise(self._in_transition)
+
+    popper_element = _get_jquery_popper_element(self)
+
+    if _has_popover(popper_element):
+        # we could instead destroy this for the user if we wanted.
+        print("Warning: creating a popover on a componet which already has a popover.")
+        print("Destroy the popover before creating a new one.")
+        return
+
+    popper_id = _get_next_id()
     max_width = _default_max_width if max_width is None else max_width
 
     # can effect the title of the popover so temporarily set it to ''
-    tooltip, self.tooltip = self.tooltip, ""
+    tooltip = getattr(self, "tooltip", None)
+    if tooltip:
+        self.tooltip = ""
 
-    popper_id = _get_random_string(5)
-    popper_element = _get_jquery_popper_element(self)
-
-    has_popover = popper_element.data("bs.popover") is not None
-    if has_popover and self._in_transition:
-        # we've been created and we're part way through a transition
-        # wait for it to finish
-        anvil.js.await_promise(self._in_transition)
-    if has_popover:
-        # clean up our previous event handlers
-        popper_element.off("show.bs.popover")
-        popper_element.off("shown.bs.popover")
-        popper_element.off("hide.bs.popover")
-        popper_element.off("hidden.bs.popover")
-
-    # transition is either None or a promise
-    self._in_transition = None
-    fake_container = _anvil.Container()
-    if component is not None:
-        # we add the component to a Container component
-        # this doesn't really add it to the dom
-        # it just allows us to use anvil's underlying show hide architecture
-        fake_container.add_component(component)
-
-    def resolve_shown(resolve, _reject):
-        def f(e):
-            resolve(None)
-            self._in_transition = None
-            popper_element.off("shown.bs.popover", f)
-
-        popper_element.on("shown.bs.popover", f)
-
-    def show_in_transition(e):
-        open_form = _anvil.get_open_form()
-        if open_form is not None and fake_container.parent is None:
-            open_form.add_component(fake_container)
-        self._in_transition = _window.Promise(resolve_shown)
-
-    popper_element.on("show.bs.popover", show_in_transition)
-
-    def resolve_hidden(resolve, _reject):
-        def f(e):
-            resolve(None)
-            self._in_transition = None
-            fake_container.remove_from_parent()
-            popper_element.off("hidden.bs.popover", f)
-
-        popper_element.on("hidden.bs.popover", f)
-
-    def hide_in_transition(e):
-        self._in_transition = _window.Promise(resolve_hidden)
-
-    popper_element.on("hide.bs.popover", hide_in_transition)
+    _add_transition_behaviour(self, component, popper_element, popper_id)
 
     if trigger == "stickyhover":
         trigger = "manual"
-        from time import sleep
-
-        def sticky_leave(e):
-            sleep(0.1)  # small delay to allow the mouse to move to the element
-            if not _S("[popover_id={}]:hover".format(popper_id)):
-                pop(self, "hide")
-
-        popper_element.on(
-            "mouseenter",
-            lambda e: None if pop(self, "is_visible") else pop(self, "show"),
-        ).on(
-            "mouseleave",
-            sticky_leave,
-        )
-        _set_sticky_hover()
-        _sticky_popovers.add(popper_id)
+        _add_sticky_behaviour(self, popper_element, popper_id)
 
     popper_element.popover(
         {
@@ -159,45 +102,44 @@ def popover(
         # otherwise the tooltip doesn't work for Buttons
         popper_element.attr("title", tooltip)
 
-    popper_element.on(
-        "show.bs.popover",
-        lambda e: _visible_popovers.update({popper_id: popper_element})
-        if auto_dismiss
-        else None,
-    ).on("hide.bs.popover", lambda e: _visible_popovers.pop(popper_id, None)).addClass(
-        "anvil-popover"
-    ).attr(
-        "popover_id", popper_id
+    popper_element.addClass("anvil-popover").attr("popover_id", popper_id).data(
+        "ae.autoDismiss", bool(auto_dismiss)
     )
 
 
 def pop(self, behavior):
     """behaviour can be any of
-    show, hide, toggle, destroy (included with bootstrap 3.3.7)
+    show, hide, toggle, destroy (included with bootstrap 3.4.1)
 
-    features added not in bootstrap 3.3.7 docs:
+    features added not in bootstrap 3.4.1 docs:
     update  - updates position of popover - useful for dynamic content that changes the size of the popover
     shown: returns True or False if the popover is visible - note a popover will only be visible after it has animated onto screen so may need to sleep(.15) before calling
     is_visible: same as shown
     """
     popper_element = _get_jquery_popper_element(self)
-    if self._in_transition is not None:
-        anvil.js.await_promise(self._in_transition)
+    if getattr(self, "_in_transition", None) is not None:
+        _anvil.js.await_promise(self._in_transition)
+
     if behavior == "shown" or behavior == "is_visible":
         return _is_visible(popper_element)
     elif behavior == "update":
         return _update_positions()
+
+    if not _has_popover(popper_element):
+        # we don't need to do anything
+        # we could raise an Exception
+        # but maybe someone wants to always detroy a popover before creating one
+        return
+
     if behavior == "hide":
-        popper_element.data(
-            "bs.popover"
-        ).inState.click = (
-            False  # see bug https://github.com/twbs/bootstrap/issues/16732
-        )
+        popper_element.data("bs.popover").inState.click = False
+        # see bug https://github.com/twbs/bootstrap/issues/16732
     elif behavior == "show":
         popper_element.data("bs.popover").inState.click = True
     elif behavior == "toggle":
         current = popper_element.data("bs.popover").inState.click
         popper_element.data("bs.popover").inState.click = not current
+
     try:
         popper_element.popover(behavior)
     except Exception:
@@ -223,28 +165,99 @@ def set_default_max_width(width):
     _default_width = width
 
 
-for _ in [_anvil.Button, _anvil.Link, _anvil.Label, _anvil.Image]:
-    _.popover = popover
-    _.pop = pop
+_anvil.Component.popover = popover
+_anvil.Component.pop = pop
 
 ######## helper functions ########
 
+_popper_count = 0
+
+
+def _get_next_id():
+    global _popper_count
+    _popper_count += 1
+    return str(_popper_count)
+
+
+def _add_transition_behaviour(self, component, popper_element, popper_id):
+    # clean up our previous event handlers
+    popper_element.off("show.bs.popover")
+    popper_element.off("shown.bs.popover")
+    popper_element.off("hide.bs.popover")
+    popper_element.off("hidden.bs.popover")
+
+    # transition is either None or a promise
+    self._in_transition = None
+    fake_container = _anvil.Container()
+    if component is not None:
+        # we add the component to a Container component
+        # this doesn't really add it to the dom
+        # it just allows us to use anvil's underlying show hide architecture
+        fake_container.add_component(component)
+
+    def resolve_shown(resolve, _reject):
+        def f(e):
+            self._in_transition = None
+            popper_element.off("shown.bs.popover", f)
+            resolve(None)
+
+        popper_element.on("shown.bs.popover", f)
+
+    def show_in_transition(e):
+        self._in_transition = _window.Promise(resolve_shown)
+        _visible_popovers[popper_id] = popper_element
+        open_form = _anvil.get_open_form()
+        if open_form is not None and fake_container.parent is None:
+            open_form.add_component(fake_container)
+
+    popper_element.on("show.bs.popover", show_in_transition)
+
+    def resolve_hidden(resolve, _reject):
+        def f(e):
+            _visible_popovers.pop(popper_id, None)
+            self._in_transition = None
+            fake_container.remove_from_parent()
+            popper_element.off("hidden.bs.popover", f)
+            resolve(None)
+
+        popper_element.on("hidden.bs.popover", f)
+
+    def hide_in_transition(e):
+        self._in_transition = _window.Promise(resolve_hidden)
+
+    popper_element.on("hide.bs.popover", hide_in_transition)
+
+
 _sticky_popovers = set()
+
+
+def _add_sticky_behaviour(self, popper_element, popper_id):
+    from time import sleep
+
+    def sticky_leave(e):
+        sleep(0.1)  # small delay to allow the mouse to move to the element
+        if not _S("[popover_id='{}']:hover".format(popper_id)):
+            pop(self, "hide")
+
+    def sticky_enter(e):
+        if not pop(self, "is_visible"):
+            pop(self, "show")
+
+    popper_element.on("mouseenter", sticky_enter).on("mouseleave", sticky_leave)
+    _set_sticky_hover()
+    _sticky_popovers.add(popper_id)
 
 
 def _sticky_leave(e):
     popper_element = None
     popover_id = _S(e.currentTarget).attr("popover_id")
     if popover_id in _sticky_popovers and not _S(
-        "[popover_id={}]:hover".format(popover_id)
+        "[popover_id='{}']:hover".format(popover_id)
     ):
         popper_element = _visible_popovers.get(popover_id)
     if popper_element is not None:
-        popper_element.data(
-            "bs.popover"
-        ).inState.click = (
-            False  # see bug https://github.com/twbs/bootstrap/issues/16732
-        )
+        popper_element.data("bs.popover").inState.click = False
+        # see bug https://github.com/twbs/bootstrap/issues/16732
         popper_element.popover("hide")
 
 
@@ -262,21 +275,17 @@ def _update_positions(*args):
 _window.addEventListener("resize", _update_positions)
 
 
-def _hide(popover_id, visible_popovers):
-    popper = visible_popovers[popover_id].popover("hide")
+def _hide(popper_element):
     # hack for click https://github.com/twbs/bootstrap/issues/16732
-    try:
-        popper.data("bs.popover").inState.click = False
-    except Exception:
-        pass
+    if _has_popover(popper_element):
+        popper_element.data("bs.popover").inState.click = False
+        popper_element.popover("hide")
 
 
 def _hide_all(e):
-    visible_popovers = _visible_popovers.copy()
-    for (
-        popover_id
-    ) in visible_popovers:  # use copy since we don't want the dict to change size
-        _hide(popover_id, visible_popovers)
+    # use copy since the dict changes size during iteration
+    for popper_element in _visible_popovers.copy().values():
+        _hide(popper_element)
 
 
 _window.addEventListener("scroll", _hide_all, True)
@@ -284,6 +293,10 @@ _window.addEventListener("scroll", _hide_all, True)
 
 def _is_visible(popper_element):
     return popper_element.attr("popover_id") in _visible_popovers
+
+
+def _has_popover(popper_element):
+    return popper_element.data("bs.popover") is not None
 
 
 def _get_jquery_popper_element(popper):
@@ -301,25 +314,22 @@ def _hide_popovers_on_outside_click(e):
         nearest_id = target.getAttribute("popover_id")
     else:
         nearest_id = _S(target).closest(".anvil-popover").attr("popover_id")
-    visible_popovers = _visible_popovers.copy()
-    for (
-        popover_id
-    ) in visible_popovers:  # use copy since we don't want the dict to change size
-        if nearest_id is not popover_id:
-            _hide(popover_id, visible_popovers)
+    # use copy since the dict changes size during iteration
+    for popover_id, popper_element in _visible_popovers.copy().items():
+        if nearest_id == popover_id:
+            continue
+        elif not popper_element.data("ae.autoDismiss"):
+            continue
+        else:
+            _hide(popper_element)
 
 
 # make this the default behaviour
 dismiss_on_outside_click(True)
 
-
-def _get_random_string(_len):
-    return "".join(_random_choice(_letters) for _ in range(_len))
-
-
 _visible_popovers = {}
 
-_template = '<div class="popover anvil-popover" role="tooltip" popover_id={} style="max-width:{}; "><div class="arrow"></div><h3 class="popover-title"></h3><div class="popover-content"></div></div>'
+_template = '<div class="popover anvil-popover" role="tooltip" popover_id="{}" style="max-width:{};"><div class="arrow"></div><h3 class="popover-title"></h3><div class="popover-content"></div></div>'
 
 # temp style for updating popovers without transition animations
 _S(

--- a/docs/guides/modules/popover.rst
+++ b/docs/guides/modules/popover.rst
@@ -17,7 +17,7 @@ Introduction
 Popovers are already included with anvil since anvil `ships with bootstrap <https://anvil.works/docs/client/javascript#already-included-javascript>`_.
 
 This module provides a python wrapper around `bootstrap popovers <https://getbootstrap.com/docs/3.4/javascript/#popovers>`_.
-When the ``popover`` module is imported Links and Buttons get two additional methods - ``pop`` and ``popover``.
+When the ``popover`` module is imported, all anvil components get two additional methods - ``pop`` and ``popover``.
 
 
 Usage
@@ -51,11 +51,11 @@ API
 
 .. method:: popover(self, content, title='', placement='right', trigger='click', animation=True, delay={"show": 100, "hide": 100}, max_width=None, auto_dismiss=True)
 
-    popover is a method that can be used with any ``Button`` or ``Link``.
+    popover is a method that can be used with any anvil component. Commonly used on ``Button``s and ``Link``s.
 
     .. describe:: self
 
-        the ``Button`` or ``Link`` used. No need to worry about this argument when using popover as a method e.g. ``self.button_1.popover(content='example text')``
+        the component used. No need to worry about this argument when using popover as a method e.g. ``self.button_1.popover(content='example text')``
 
     .. describe:: content
 
@@ -88,26 +88,29 @@ API
 
     .. describe:: auto_dismiss
 
-        when clicking outside a popover the popover will be closed. Setting this flag to ``False`` overrides that behaviour.
+        When clicking outside a popover the popover will be closed. Setting this flag to ``False`` overrides that behaviour.
+        Note that popovers will always be dismissed when the page is scrolled. This prevents popovers from appearing in weird places on the page.
 
 
 .. method:: pop(self, behaviour)
 
-    pop is a method that can be used with any ``Button`` or ``Link`` that has a ``popover``
+    pop is a method that can be used with any component that has a ``popover``
 
     .. describe:: self
 
-        the ``Button`` or ``Link`` used. No need to worry about this argument when using ``self.button_1.pop('show')``
+        the component used. No need to worry about this argument when using ``self.button_1.pop('show')``
 
     .. describe:: behaviour
 
-        ``'show'``, ``'hide'``, ``'toggle'``, ``'destroy'``. Also includes ``'shown'`` and ``'is_visible'`` which return a ``boolean``.
+        ``'show'``, ``'hide'``, ``'toggle'``, ``'destroy'``. Also includes ``'shown'`` and ``'is_visible'``, which return a ``boolean``.
+        ``'update'`` will update the popover's position. This is useful when a popover's height changes dynamically.
 
 
 
 .. function:: dismiss_on_outside_click(dismiss=True)
 
     by default if you click outside of a popover the popover will close. This behaviour can be overridden globally by calling this function. It can also be set per popover using the ``auto_dismiss`` argument.
+    Note that popovers will always be dismissed when the page is scrolled. This prevents popovers from appearing in weird places on the page.
 
 .. function:: set_default_max_width(width)
 


### PR DESCRIPTION
This pr does a refactor of popovers.

Features have been added and the main popover function was becoming a bit swamped.

It also closes #151:
 - scroll behaviour will always hide popovers (regardless of whether `auto_dismiss` is true)
 - This is because - when scrolling the page - popovers always appear on top and that can cause ghost popovers that float even though their popper component is no longer visible.

Other changes:
-  all Components can have popovers (not just Links and Buttons)
- `popover_id` is no longer a random string just the str of the next count
- `_set_transition` moved to be an attribute on the jQuery element rather than adding an attribute to the component instance.
- improved scrolling/resize behaviour that is a little cleverer.


It builds on top of #150 