### PR TITLE
Use js.import_from in a few places

### DIFF
--- a/client_code/Slider/__init__.py
+++ b/client_code/Slider/__init__.py
@@ -5,17 +5,14 @@
 #
 # This software is published at https://github.com/anvilistas/anvil-extras
 
+import anvil.js
 from anvil import HtmlPanel as _HtmlPanel
-from anvil import *
-from anvil.js import get_dom_node as _get_dom_node
-from anvil.js import window as _window
 
 from .. import session
 from ..utils._component_helpers import _add_script, _get_color, _spacing_property
 from ._anvil_designer import SliderTemplate
 
 __version__ = "1.6.0"
-
 
 _add_script(
     '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/nouislider@15.4.0/dist/nouislider.min.css"></link>'
@@ -47,10 +44,7 @@ session.style_injector.inject(
 """
 )
 
-_add_script(
-    '<script src="https://cdn.jsdelivr.net/npm/nouislider@15.4.0/dist/nouislider.min.js"></script>'
-)
-_Slider = _window.noUiSlider
+_Slider = anvil.js.import_from("https://cdn.skypack.dev/nouislider@15.4.0").default
 
 
 import json
@@ -247,7 +241,7 @@ _defaults = {
 class Slider(SliderTemplate):
     def __init__(self, **properties):
         # Any code you write here will run when the form opens.
-        dom_node = self._dom_node = _get_dom_node(self)
+        dom_node = self._dom_node = anvil.js.get_dom_node(self)
         dom_node.classList.add("anvil-slider-container")
 
         self._slider_node = dom_node.querySelector(".anvil-slider")

--- a/client_code/storage.py
+++ b/client_code/storage.py
@@ -8,18 +8,12 @@
 import anvil.js
 from anvil.js import window as _window
 
-from utils._component_helpers import _add_script
-
 __version__ = "1.6.0"
 __all__ = ["local_storage", "indexed_db"]
 
-_add_script(
-    """
-<script src="https://cdn.jsdelivr.net/npm/localforage@1.10.0/dist/localforage.min.js"></script>
-"""
-)
+_ForageModule = anvil.js.import_from("https://cdn.skypack.dev/localforage@1.10.0")
 
-_forage = _window.localforage
+_forage = _ForageModule.default
 _forage.dropInstance()
 
 

--- a/client_code/uuid.py
+++ b/client_code/uuid.py
@@ -5,11 +5,11 @@
 #
 # This software is published at https://github.com/anvilistas/anvil-extras
 
-from anvil.js.window import eval as _eval
+import anvil.js
 
 __version__ = "1.6.0"
 
-_js_uuid = _eval("import('https://jspm.dev/uuid@8.3.2');")
+_js_uuid = anvil.js.import_from("https://jspm.dev/uuid@8.3.2")
 _v4, _parse, _validate = _js_uuid.v4, _js_uuid.parse, _js_uuid.validate
 
 


### PR DESCRIPTION
A new anvil.js feature which simplifies a couple of javascript library imports for us.
I've identified a few places where we can import modern javascript modules into python using it.

Also removed `from anvil import *` in the slider component which didn't seem to be being used at all 🤷 

(Checked all working on the demo app and ran the modules as main)