### PR TITLE
storage updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+
+# Unreleased
+
+* storage supports `datetime` and `date` objects
+  https://github.com/anvilistas/anvil-extras/pull/179
+
 # v1.8.1 14-Oct-2021
 
 ## Updates

--- a/client_code/storage.py
+++ b/client_code/storage.py
@@ -304,10 +304,10 @@ if __name__ == "__main__":
         print(list(_) == list(_.keys()))
         _.clear()
         print(len(list(_.keys())) == 0)
-        print("==========")
         from datetime import datetime
 
         try:
             _["foo"] = datetime.now()
         except TypeError:
-            pass
+            print("TypeError raised successfully")
+        print("==========")

--- a/client_code/storage.py
+++ b/client_code/storage.py
@@ -303,31 +303,38 @@ if __name__ == "__main__":
     for _ in local_storage, indexed_db:
         print(_)
         _["foo"] = "bar"
-        print(_["foo"])
+        assert _["foo"] == "bar"
         del _["foo"]
-        print(_.get("foo", "sentinel"))
+        assert _.get("foo", "sentinel") == "sentinel"
         try:
             _["foo"]
-        except KeyError as e:
-            print(repr(e))
+        except KeyError:
+            pass
+        else:
+            raise AssertionError
         _.put("foo", 1)
-        print(_.pop("foo"))
+        assert _.pop("foo") == 1
         x = [{"a": "b"}, "foo"]
         _["x"] = x
-        print(_["x"])
-        print(_["x"] == x)
-        print(_.get("x") == x)
-        print(_.pop("x") == x)
+        assert _["x"] == x == _.get("x") == _.pop("x")
         _["foo"] = None
         _["eggs"] = None
         _.update({"foo": "bar"}, eggs="spam", x=1)
         for i in _:  # shouldn't fail
             pass
-        print(len(list(_.keys())) == 3, _["eggs"] == "spam")
-        print(list(_) == list(_.keys()))
+        assert len(list(_.keys())) == 3 and _["eggs"] == "spam"
+        assert list(_) == list(_.keys())
 
-        _["foo"] = [datetime.now(), datetime.now().astimezone(), date.today()]
-        print(_["foo"])
+        date_objs = [datetime.now(), datetime.now().astimezone(), date.today()]
+        _["d"] = date_objs
+        assert _["d"] == date_objs
+        try:
+            _["foo"] = slice(1, 2, 3)
+        except TypeError:
+            pass
+        else:
+            raise AssertionError
 
         _.clear()
-        print(len(list(_.keys())) == 0)
+        assert len(_) == 0
+        print("===== Tests Passed =====")

--- a/docs/guides/modules/storage.rst
+++ b/docs/guides/modules/storage.rst
@@ -19,7 +19,8 @@ Which to chose?
 | If you have small amounts of data which can be converted to JSON - use :attr:`local_storage`.
 | If you have more data which can be converted to JSON (also ``bytes``) - use :attr:`indexed_db`.
 
-*NB: Datetime objects cannot be stored. You'll need to serialize and deserialize these - consider converting datetimes to timestamps (and dates to ordinals).*
+``datetime`` and ``date`` objects are also supported.
+If you want to store anything else you'll need to convert it to something JSONable first.
 
 
 Usage Examples
@@ -118,8 +119,9 @@ API
 
     .. describe:: store[key] = value
 
-        Set ``store[key]`` to *value*. If the value is not a JSONable data type it may be stored incorrectly. e.g. a ``datetime`` object.
+        Set ``store[key]`` to *value*. If the value is not a JSONable data type it may be stored incorrectly.
         If storing ``bytes`` objects it is best to use the :attr:`indexed_db` store.
+        ``datetime`` and ``date`` objects are also supported.
 
     .. describe:: del store[key]
 


### PR DESCRIPTION
close #176 - add a serializer to fail loudly
close #102 - support serializing datetimes

fix a bug with iterating over a storage object.
`__iter__` can't suspend.