### PR TITLE
routing: on form load

### DIFF
--- a/client_code/routing/_routing.py
+++ b/client_code/routing/_routing.py
@@ -123,11 +123,12 @@ def main_router(Cls):
                 f"\nurl_pattern = {url_pattern}\nurl_dict    = {url_dict}"
             )
 
-            if getattr(Cls, "on_navigation", None):
+            super_on_navigation = getattr(Cls, "on_navigation", None)
+            if super_on_navigation is not None:
                 logger.print(f"{Cls.__name__} on_navigation called")
                 # on_navigation in your main form will be called here
                 # in the example we change 'selected' role on links using this method
-                Cls.on_navigation(
+                super_on_navigation(
                     self,
                     url_hash=url_hash,
                     url_pattern=url_pattern,
@@ -233,6 +234,15 @@ def main_router(Cls):
                 _navigation.setTitle(form._route_title)
                 self.content_panel.clear()
                 self.content_panel.add_component(form, full_width_row=form._f_w_r)
+                super_on_form_load = getattr(Cls, "on_form_load", None)
+                if super_on_form_load is not None:
+                    super_on_form_load(
+                        self,
+                        url_hash=url_hash,
+                        url_pattern=url_pattern,
+                        url_dict=url_dict,
+                        form=form,
+                    )
 
     MainRouter.__name__ = Cls.__name__
     MainRouter.__module__ = Cls.__module__


### PR DESCRIPTION
Just an idea based on this post:
https://anvil.works/forum/t/anvil-extras-v1-8/10167/4

I think the poster has the module locally - so has patched that change in.
(The `form_load()` method is not exposed to the developer)
This pr allows others to do the same

```python
@routing.main_router
class MainForm(MainFormTemplate):
    ...
    def on_navigation(self, **nav_args):
        """called when the url hash changes"""
        unload_form = nav_args["unload_form"]
        animate(unload_form, fade_out, duration=300).wait()

    def on_form_load(self, **nav_args):
        """called after a form is loaded into the content panel"""
        form = nav_args["form"]
        animate(form, fade_in, duration=300)
```

---

the only api alternative I thought about was `on_form_loaded` vs `on_form_load`

---

While i still muster the energy to move the docs over i've added some documentation in the parallel pr
https://github.com/s-cork/HashRouting/pull/14

