### PR TITLE
Popover multiselect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   This method will be fired with the current `url_hash` and the `form` that was added to the `content_panel`.
   https://github.com/anvilistas/anvil-extras/pull/180
 
+## Bug fixes
+* MultiSelect component works correctly in a popover
+  https://github.com/anvilistas/anvil-extras/pull/187
+
+
 # v1.8.1 14-Oct-2021
 
 ## Updates

--- a/client_code/MultiSelectDropDown/form_template.yaml
+++ b/client_code/MultiSelectDropDown/form_template.yaml
@@ -34,4 +34,4 @@ container:
       count > 3\"\n></select>\n<script type=\"module\">\nimport {DesignerMultiSelectDropDown}\
       \ from \"https://deno.land/x/anvil_extras@dev-1.2.1/js/designer_components/bundle.min.js\"\
       ;\nDesignerMultiSelectDropDown.init();\n</script>"}
-  event_bindings: {hide: _form_hide}
+  event_bindings: {hide: _form_hide, show: _form_show}

--- a/client_code/popover.py
+++ b/client_code/popover.py
@@ -23,6 +23,8 @@ __version__ = "1.8.1"
 
 __all__ = ["popover", "pop", "dismiss_on_outside_click", "set_default_max_width"]
 
+_warnings = {"has_pop": False, "has_parent": False}
+
 
 def popover(
     self,
@@ -66,9 +68,11 @@ def popover(
         msg = (
             "Warning: attempted to create a popover on a component that already has one. This will have no effect.\n"
             "Destroy the popover before creating a new one using component.pop('destroy').\n"
-            "Or, use has_popover() to check if this component aleady has a popover."
+            "Or, use has_popover() to check if this component aleady has a popover before creating a new one."
         )
-        print(msg)
+        if not _warnings.get("has_pop"):
+            print(msg)
+        _warnings["has_pop"] = True
         # return here since adding a new popover has no effect
         return
 
@@ -218,10 +222,12 @@ def _add_transition_behaviour(component, popper_element, popper_id):
                 fake_container.add_component(component)
             elif type(component.parent) is _anvil.Container:
                 pass  # just ignore this - it's probably something internal
-            else:
+            elif not _warnings.get("has_parent"):
                 print(
-                    "Warning: the popover content already has a parent this can cause strange behaviour"
+                    "Warning: the popover content already has a parent this can cause unusual behaviour."
+                    "Support for this may be removed in a future version."
                 )
+                _warnings["has_parent"] = True
 
         popper_element.on("shown.bs.popover", f)
 

--- a/client_code/popover.py
+++ b/client_code/popover.py
@@ -306,9 +306,13 @@ _window.addEventListener("resize", _update_positions)
 _scrolling = False
 
 
-def _hide_on_scroll(*e):
+def _hide_on_scroll(e):
     global _scrolling
-    if _scrolling or not _visible_popovers:
+    if (
+        _scrolling
+        or not _visible_popovers
+        or e.target.closest(".anvil-popover") is not None
+    ):
         return
 
     _scrolling = True

--- a/client_code/popover.py
+++ b/client_code/popover.py
@@ -206,20 +206,28 @@ def _add_transition_behaviour(component, popper_element, popper_id):
             _set_data(popper_element, "inTransition", None)
             popper_element.off("shown.bs.popover", f)
             resolve(None)
+            open_form = _anvil.get_open_form()
+            if open_form is not None and fake_container.parent is None:
+                open_form.add_component(fake_container)
+            if component is None:
+                return
+            elif component.parent is None:
+                # we add the component to a Container component
+                # this doesn't really add it to the dom
+                # it just allows us to use anvil's underlying show hide architecture
+                fake_container.add_component(component)
+            elif type(component.parent) is _anvil.Container:
+                pass  # just ignore this - it's probably something internal
+            else:
+                print(
+                    "Warning: the popover content already has a parent this can cause strange behaviour"
+                )
 
         popper_element.on("shown.bs.popover", f)
 
     def show_in_transition(e):
         _set_data(popper_element, "inTransition", _Promise(resolve_shown))
         _visible_popovers[popper_id] = popper_element
-        open_form = _anvil.get_open_form()
-        if open_form is not None and fake_container.parent is None:
-            open_form.add_component(fake_container)
-        if component is not None and component.parent is None:
-            # we add the component to a Container component
-            # this doesn't really add it to the dom
-            # it just allows us to use anvil's underlying show hide architecture
-            fake_container.add_component(component)
 
     popper_element.on("show.bs.popover", show_in_transition)
 


### PR DESCRIPTION
Some fixes to close #186 

Turns out there was a race condition in the hide event.
The exact fix comes from looking at the library code and specifically this line:
https://github.com/snapappointments/bootstrap-select/blob/6c4c75f61e69ca54d5ab557a2b90ffdccf1c63cd/js/bootstrap-select.js#L2233

The hide event/toggle version ended up being too late since the component had already been removed from the screen.
Getting the actually menu container and calling its jquery detach method works well.

I adjust the warnings so that they only get fired once.
Someone mentioned they got a bunch of warnings in a repeating panel. One is probably enough 😄 

The scroll event change was strange. But I needed that for #186 for some reason.

I also moved firing the show event for the anvil-container to the `shown.bs.popover` event rather than `show.bs.popover` since it's not yet on the screen in the `show` event. And anvil `show` events expect things to be on the screen.
This was important for allowing the multi-select component to know if it was inside popover or not.