### PR TITLE
routing: put exports in the __init__ explicitly

### DIFF
--- a/client_code/routing/__init__.py
+++ b/client_code/routing/__init__.py
@@ -7,4 +7,25 @@
 
 __version__ = "1.8.1"
 
-from ._routing import *
+from ._routing import (
+    add_to_cache,
+    clear_cache,
+    error_form,
+    get_cache,
+    get_url_components,
+    get_url_dict,
+    get_url_hash,
+    get_url_pattern,
+    go,
+    go_back,
+    load_error_form,
+    load_form,
+    logger,
+    main_router,
+    on_session_expired,
+    reload_page,
+    remove_from_cache,
+    route,
+    set_url_hash,
+    set_warning_before_app_unload,
+)


### PR DESCRIPTION
Looks like import * doesn't get transferred to autocompletions.

whereas explicit named imports does.