### PR TITLE
correct_canvas_resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## New Features
 * Dynamic serialisation of data tables rows
   https://github.com/anvilistas/anvil-extras/pull/191
+* `util.correct_canvas_resolution()` - canvas elements can look blurry on retina displays
+  This function sharpens the resolution of a canvas element when called in the reset event
+  https://github.com/anvilistas/anvil-extras/pull/202
 
 ## Updates:
 * storage supports `datetime` and `date` objects

--- a/client_code/utils/__init__.py
+++ b/client_code/utils/__init__.py
@@ -11,12 +11,18 @@ __version__ = "1.8.1"
 
 
 def __dir__():
-    return ["auto_refreshing", "wait_for_writeback", "timed", "BindingRefreshDict"]
+    return [
+        "auto_refreshing",
+        "wait_for_writeback",
+        "timed",
+        "BindingRefreshDict",
+        "correct_canvas_resolution",
+    ]
 
 
 @cache
 def __getattr__(name):
-    # todo use dynamic imports but __import__ is not yet supported in skult
+    # todo use dynamic imports but __import__ is not yet supported in skulpt
     if name == "auto_refreshing":
         from ._auto_refreshing import auto_refreshing
 
@@ -33,5 +39,9 @@ def __getattr__(name):
         from ._auto_refreshing import BindingRefreshDict
 
         return BindingRefreshDict
+    elif name == "correct_canvas_resolution":
+        from ._canvas_helpers import correct_canvas_resolution
+
+        return correct_canvas_resolution
     else:
         raise AttributeError(name)

--- a/client_code/utils/_canvas_helpers.py
+++ b/client_code/utils/_canvas_helpers.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright (c) 2021 The Anvil Extras project team members listed at
+# https://github.com/anvilistas/anvil-extras/graphs/contributors
+#
+# This software is published at https://github.com/anvilistas/anvil-extras
+
+from anvil import Canvas as _Canvas
+from anvil.js import get_dom_node as _dom_node
+from anvil.js import window as _window
+
+__version__ = "1.8.1"
+
+
+def correct_canvas_resolution(canvas):
+    """call this function in the reset event for a canvas element.
+    It will reduce blurryness of canvas elements on retina screens"""
+    assert isinstance(canvas, _Canvas), "expected a Canvas object as the first argument"
+    dpr = max(_window.devicePixelRatio, 2)
+    dom_c = _dom_node(canvas)
+    rect = dom_c.getBoundingClientRect()
+    new_width = int(rect.width * dpr)
+    if dom_c.width == new_width:
+        # we've done this scaling already
+        return
+    dom_c.width = new_width
+    dom_c.height = int(rect.height * dpr)
+    ctx = dom_c.getContext("2d")
+    # scale all drawing options by the dpr
+    # so we don't worry about the difference
+    ctx.scale(dpr, dpr)

--- a/docs/guides/modules/utils.rst
+++ b/docs/guides/modules/utils.rst
@@ -107,3 +107,23 @@ To use ``wait_for_writeback``, import the decorator and apply it to a function, 
 
 
 The click event will now only be called after all active writebacks have finished executing.
+
+
+Correct Canvas Resolution
+-------------------------
+
+Canvas elements can appear blurry on retina screens.
+This helper function ensures a canvas element appears sharp.
+It should be called inside the canvas ``reset`` event.
+
+.. code-block:: python
+
+   from anvil_extras.utils import correect_canvas_resolution
+
+   class MyForm(MyFormTemplate):
+        ...
+
+        def canvas_reset(self, **event_args):
+            c = self.canvas
+            correect_canvas_resolution(c)
+            ...


### PR DESCRIPTION
A little helper function that reduces the blurriness of canvas
based on a post I made a couple of years ago: https://anvil.works/forum/t/canvas-resolution-blurry/3765

Code from: https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio#correcting_resolution_in_a_canvas

The difference
<img width="374" alt="Screenshot 2021-10-31 at 22 41 58" src="https://user-images.githubusercontent.com/36813890/139588914-0aebdd60-e45d-42eb-b7c4-f682bcfe3e1e.png">


