### PR TITLE
Multiselect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
   add ``dismiss_on_scroll()`` and ``set_default_container()`` methods
   https://github.com/anvilistas/anvil-extras/pull/268
 
+## Bug fixes
+* Multi-select - fix button clicks don't always close the dropdown menu
+  https://github.com/anvilistas/anvil-extras/issues/271
+
 
 # v1.9.0 27-Jan-2022
 

--- a/client_code/MultiSelectDropDown/__init__.py
+++ b/client_code/MultiSelectDropDown/__init__.py
@@ -57,7 +57,7 @@ _defaults = {
     "enabled": True,
     "spacing_below": "small",
     "spacing_above": "small",
-    "enable_select_all": True,
+    "enable_select_all": False,
 }
 
 

--- a/client_code/MultiSelectDropDown/__init__.py
+++ b/client_code/MultiSelectDropDown/__init__.py
@@ -40,6 +40,15 @@ _html_injector.cdn(f"{prefix}{bs_select_version}/dist/css/bootstrap-select.min.c
 _S.fn.selectpicker.Constructor.BootstrapVersion = "3"
 
 
+def off_dd_click(e):
+    # see bug #271
+    if not e.target.closest(".bootstrap-select"):
+        _S(_document).trigger("click.bs.dropdown.data-api")
+
+
+_document.addEventListener("click", off_dd_click, True)
+
+
 _defaults = {
     "align": "left",
     "placeholder": "None Selected",

--- a/client_code/MultiSelectDropDown/form_template.yaml
+++ b/client_code/MultiSelectDropDown/form_template.yaml
@@ -8,7 +8,7 @@ properties:
   important: true}
 - {name: multiple, type: boolean, default_value: true, group: interaction, important: true}
 - {name: enabled, type: boolean, default_value: true, group: interaction, important: true}
-- {name: enable_select_all, type: boolean, default_value: true, group: interaction, important: true}
+- {name: enable_select_all, type: boolean, default_value: false, group: interaction, important: true}
 - {name: visible, type: boolean, default_value: true, group: appearance, important: true}
 - {name: spacing_above, type: string, default_value: small, group: layout, important: false}
 - {name: spacing_below, type: string, default_value: small, group: layout, important: false}


### PR DESCRIPTION
close #271 

This is because the anvil button stops the propagation of the event.
But the dropdown uses a document jQuery click event to toggle itself - which doesn't get fired!
We add a click capture event to the document, which fires before anvil's button event.

I also think that `enable_select_all` should default to False.
I didn't spot it in #255 


