### PR TITLE
popovers: adjust approach for components that have elements outside of dom tree

### DIFF
--- a/client_code/Autocomplete/__init__.py
+++ b/client_code/Autocomplete/__init__.py
@@ -79,6 +79,7 @@ class Autocomplete(AutocompleteTemplate):
         dom_node.addEventListener("input", self._on_input)
         dom_node.addEventListener("focus", self._on_focus, True)
         dom_node.addEventListener("blur", self._on_blur)
+        dom_node.addEventListener("popover.content", self._mk_popover)
 
         # ensure the same method is passed to $(window).off('resize')
         self._reset_position = self._reset_position
@@ -219,6 +220,9 @@ class Autocomplete(AutocompleteTemplate):
         """This method is called when the TextBox is removed from the screen"""
         _document.body.removeChild(self._lp_node)
         _S(_window).off("resize", self._reset_position)
+
+    def _mk_popover(self, e):
+        e.detail(self._lp_node)
 
     ##### Properties ######
     @property

--- a/client_code/Autocomplete/__init__.py
+++ b/client_code/Autocomplete/__init__.py
@@ -79,7 +79,7 @@ class Autocomplete(AutocompleteTemplate):
         dom_node.addEventListener("input", self._on_input)
         dom_node.addEventListener("focus", self._on_focus, True)
         dom_node.addEventListener("blur", self._on_blur)
-        dom_node.addEventListener("popover.content", self._mk_popover)
+        self.set_event_handler("x-popover-init", self._mk_popover)
 
         # ensure the same method is passed to $(window).off('resize')
         self._reset_position = self._reset_position
@@ -221,8 +221,8 @@ class Autocomplete(AutocompleteTemplate):
         _document.body.removeChild(self._lp_node)
         _S(_window).off("resize", self._reset_position)
 
-    def _mk_popover(self, e):
-        e.detail(self._lp_node)
+    def _mk_popover(self, init_node, **event_args):
+        init_node(self._lp_node)
 
     ##### Properties ######
     @property

--- a/client_code/MultiSelectDropDown/__init__.py
+++ b/client_code/MultiSelectDropDown/__init__.py
@@ -101,7 +101,7 @@ class MultiSelectDropDown(MultiSelectDropDownTemplate):
 
         self._el.selectpicker()
         self._el.on("changed.bs.select", self.change)
-        self._dom_node.addEventListener("popover.content", self._mk_popover)
+        self.set_event_handler("x-popover-init", self._mk_popover)
         self._init = True
 
     ##### PROPERTIES #####
@@ -181,9 +181,9 @@ class MultiSelectDropDown(MultiSelectDropDownTemplate):
     def change(self, *e):
         return self.raise_event("change")
 
-    def _mk_popover(self, e):
+    def _mk_popover(self, init_node, **event_args):
         # this is a bit of a hack - we're using the libraries private methods for this
-        e.detail(self._el.data("selectpicker")["$bsContainer"])
+        init_node(self._el.data("selectpicker")["$bsContainer"])
 
 
 ##### PRIVATE Functions #####

--- a/client_code/MultiSelectDropDown/__init__.py
+++ b/client_code/MultiSelectDropDown/__init__.py
@@ -86,9 +86,10 @@ class MultiSelectDropDown(MultiSelectDropDownTemplate):
         self._init = False
 
         self._dom_node = _js.get_dom_node(self)
-        self._el = _S(self._dom_node).find("select")
+        _S_dom_node = _S(self._dom_node)
+        self._el = _S_dom_node.find("select")
 
-        _S(self._dom_node).html("").append(self._el)
+        _S_dom_node.html("").append(self._el)
         # remove all the script tags before they load into the dom
 
         self._values = {}
@@ -100,6 +101,7 @@ class MultiSelectDropDown(MultiSelectDropDownTemplate):
 
         self._el.selectpicker()
         self._el.on("changed.bs.select", self.change)
+        self._dom_node.addEventListener("popover.content", self._mk_popover)
         self._init = True
 
     ##### PROPERTIES #####
@@ -179,18 +181,9 @@ class MultiSelectDropDown(MultiSelectDropDownTemplate):
     def change(self, *e):
         return self.raise_event("change")
 
-    def _form_hide(self, **event_args):
+    def _mk_popover(self, e):
         # this is a bit of a hack - we're using the libraries private methods for this
-        bs_container = self._el.data("selectpicker")["$bsContainer"]
-        bs_container.removeClass("anvil-popover").attr("popover_id", None).detach()
-
-    def _form_show(self, **event_args):
-        popover = self._dom_node.closest(".anvil-popover")
-        if popover is None:
-            return
-        pop_id = popover.getAttribute("popover_id")
-        bs_container = self._el.data("selectpicker")["$bsContainer"]
-        bs_container.addClass("anvil-popover").attr("popover_id", pop_id)
+        e.detail(self._el.data("selectpicker")["$bsContainer"])
 
 
 ##### PRIVATE Functions #####

--- a/client_code/MultiSelectDropDown/form_template.yaml
+++ b/client_code/MultiSelectDropDown/form_template.yaml
@@ -35,4 +35,3 @@ container:
       count > 3\"\n></select>\n<script type=\"module\">\nimport {DesignerMultiSelectDropDown}\
       \ from \"https://deno.land/x/anvil_extras@dev-1.8.2-c/js/designer_components/bundle.min.js\"\
       ;\nDesignerMultiSelectDropDown.init();\n</script>"}
-  event_bindings: {hide: _form_hide, show: _form_show}

--- a/client_code/popover.py
+++ b/client_code/popover.py
@@ -17,10 +17,11 @@ from time import sleep
 
 import anvil as _anvil
 from anvil.js import window as _window
-from anvil.js.window import CustomEvent as _CustomEvent
 from anvil.js.window import Promise as _Promise
 from anvil.js.window import document as _document
 from anvil.js.window import jQuery as _S
+
+from .utils._component_helpers import walk as _walk
 
 __version__ = "1.9.0"
 
@@ -127,11 +128,8 @@ def popover(
     )
 
     if component is not None:
-        # this event can be caught by components e.g. autocomplete etc
-        event = _CustomEvent("popover.content", {"detail": make_popover})
-        content.dispatchEvent(event)
-        for child in content.querySelectorAll(".anvil-component"):
-            child.dispatchEvent(event)
+        for c in _walk(component):
+            c.raise_event("x-popover-init", init_node=make_popover)
 
 
 def pop(self, behavior):

--- a/client_code/utils/_component_helpers.py
+++ b/client_code/utils/_component_helpers.py
@@ -7,6 +7,7 @@
 import random
 
 import anvil.js
+from anvil import Component as _Component
 from anvil import app as _app
 from anvil.js import get_dom_node as _get_dom_node
 from anvil.js.window import Promise as _Promise
@@ -119,3 +120,18 @@ def _get_rgb(value):
             f"expected a hex value, theme color or rgb value, not, {value}"
         )
     return value
+
+
+def _walker(children):
+    for child in children:
+        yield child
+        get_children = getattr(child, "get_components", None)
+        if get_children is not None:
+            yield from _walker(get_children())
+
+
+def walk(component_or_components):
+    """yields the component(s) passed in and all their children"""
+    if isinstance(component_or_components, _Component):
+        component_or_components = [component_or_components]
+    yield from _walker(component_or_components)


### PR DESCRIPTION
This simplifies the approach for making certain components work with popovers.
The components that are problematic are those that have elements outside of the dom tree structure of the main component.

e.g. multiselect and autocomplete both have elements that don't exist as child elements
That means when they're clicked the popover would close, but it shouldn't.

The first commit uses an approach taken was to use a custom javascript event.
The second approach walks child components and raise a custom event
The second approach is probably nicer.
