### PR TITLE
Add production urls to skypack.dev imports

### DIFF
--- a/client_code/Slider/__init__.py
+++ b/client_code/Slider/__init__.py
@@ -55,7 +55,7 @@ _html_injector.css(
 )
 
 _Slider = anvil.js.import_from(
-    f"https://cdn.skypack.dev/nouislider@{noui_version}"
+    "https://cdn.skypack.dev/pin/nouislider@v15.4.0-qwAfTOVKkfvhMhVnBPSn/mode=imports,min/optimized/nouislider.js"
 ).default
 
 

--- a/client_code/storage.py
+++ b/client_code/storage.py
@@ -13,7 +13,9 @@ from anvil.js import window as _window
 __version__ = "1.9.0"
 __all__ = ["local_storage", "indexed_db"]
 
-_ForageModule = anvil.js.import_from("https://cdn.skypack.dev/localforage@1.10.0")
+_ForageModule = anvil.js.import_from(
+    "https://cdn.skypack.dev/pin/localforage@v1.10.0-vSTz1U7CF0tUryZh6xTs/mode=imports,min/optimized/localforage.js"
+)
 
 _forage = _ForageModule.default
 _forage.dropInstance()


### PR DESCRIPTION
Reading skypack docs suggests this is better for production

smaller, faster load of javascript libraries which seems like a win.

See docs:
https://docs.skypack.dev/skypack-cdn/api-reference/pinned-urls-optimized