### PR TITLE
Fixed typo in default_template

### DIFF
--- a/docs/guides/modules/routing.rst
+++ b/docs/guides/modules/routing.rst
@@ -70,7 +70,7 @@ This is equivalent to:
 
 .. code:: python
 
-    @routing.defult_template
+    @routing.default_template
     class Main(MainTemplate):
 
 


### PR DESCRIPTION
Minor type that nevertheless made copying and pasting the default template decorator give an error