### PR TITLE
Routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+## Features
+* routing -  a template argument was added to the `@routing.route` decorator.
+  This argument determines which templates a route can be added to.
+  https://github.com/anvilistas/anvil-extras/issues/293
+
+
 # v2.0.1 16-Mar-2022
 
 ## BugFixes:

--- a/client_code/routing/_decorators.py
+++ b/client_code/routing/_decorators.py
@@ -29,6 +29,7 @@ def template(path="", priority=0, condition=None):
 
         def on_show(sender, **e):
             sender.remove_event_handler("show", on_show)
+            # wait till the show event so that this template is the open_form before re-navigating
             _router.launch()
 
         @wraps(cls_init)

--- a/client_code/routing/_router.py
+++ b/client_code/routing/_router.py
@@ -231,6 +231,10 @@ def path_matcher(template_info, url_hash, url_pattern, url_dict):
     valid_routes = _routes.get(template_info.form.__name__, []) + _routes.get(None, [])
 
     for route_info in valid_routes:
+        if not route_info.url_pattern.startswith(template_info.path):
+            route_info = route_info._replace(
+                url_pattern=template_info.path + route_info.url_pattern
+            )
         if num_given_parts != len(route_info.url_parts):
             # url pattern CANNOT fit, skip deformatting
             continue

--- a/client_code/routing/_router.py
+++ b/client_code/routing/_router.py
@@ -193,11 +193,13 @@ def clear_container():
 
 def get_form_to_add(template_info, url_hash, url_pattern, url_dict, properties):
     global _current_form
-    path, dynamic_vars = path_matcher(template_info, url_hash, url_pattern, url_dict)
+    route_info, dynamic_vars = path_matcher(
+        template_info, url_hash, url_pattern, url_dict
+    )
 
     # check if path is cached with another template
-    if len(path.templates) > 1:
-        for template in path.templates:
+    if len(route_info.templates) > 1:
+        for template in route_info.templates:
             form = _cache.get((url_hash, template), None)
             if form is not None:
                 logger.debug(
@@ -205,14 +207,14 @@ def get_form_to_add(template_info, url_hash, url_pattern, url_dict, properties):
                 )
                 return form
 
-    form = path.form.__new__(path.form, **properties)
+    form = route_info.form.__new__(route_info.form, **properties)
     logger.debug(f"adding {form.__class__.__name__!r} to cache")
     _current_form = _cache[url_hash] = form
     form._routing_props = {
-        "title": path.title,
-        "layout_props": {"full_width_row": path.fwr},
+        "title": route_info.title,
+        "layout_props": {"full_width_row": route_info.fwr},
     }
-    form.url_keys = path.url_keys
+    form.url_keys = route_info.url_keys
     form.url_pattern = url_pattern
     form.url_dict = url_dict
     form.url_hash = url_hash

--- a/client_code/routing/_router.py
+++ b/client_code/routing/_router.py
@@ -194,6 +194,17 @@ def clear_container():
 def get_form_to_add(template_info, url_hash, url_pattern, url_dict, properties):
     global _current_form
     path, dynamic_vars = path_matcher(template_info, url_hash, url_pattern, url_dict)
+
+    # check if path is cached with another template
+    if len(path.templates) > 1:
+        for template in path.templates:
+            form = _cache.get((url_hash, template), None)
+            if form is not None:
+                logger.debug(
+                    f"Loading {form.__class__.__name__!r} from cache - cached with {template!r}"
+                )
+                return form
+
     form = path.form.__new__(path.form, **properties)
     logger.debug(f"adding {form.__class__.__name__!r} to cache")
     _current_form = _cache[url_hash] = form

--- a/client_code/routing/_router.py
+++ b/client_code/routing/_router.py
@@ -5,6 +5,7 @@
 #
 # This software is published at https://github.com/anvilistas/anvil-extras
 
+from functools import wraps
 from itertools import chain
 
 from anvil import get_open_form, open_form
@@ -41,12 +42,35 @@ class _StackDepthContext:
             return True
 
 
+def _update_key(key):
+    if type(key) is str:
+        key = (key, type(get_open_form()).__name__)
+    return key
+
+
+def _wrap_method(method):
+    @wraps(method)
+    def wrapped(self, key, *args):
+        return method(self, _update_key(key), *args)
+
+    return wrapped
+
+
+class _Cache(dict):
+    __getitem__ = _wrap_method(dict.__getitem__)
+    __setitem__ = _wrap_method(dict.__setitem__)
+    __delitem__ = _wrap_method(dict.__delitem__)
+    get = _wrap_method(dict.get)
+    pop = _wrap_method(dict.pop)
+    setdefault = _wrap_method(dict.setdefault)
+
+
 stack_depth_context = _StackDepthContext()
 default_title = document.title
 
 _current_form = None
-_cache = {}
-_routes = []
+_cache = _Cache()
+_routes = {}
 _templates = set()
 _ordered_templates = {}
 _error_form = None
@@ -83,7 +107,7 @@ def navigate(url_hash=None, url_pattern=None, url_dict=None, **properties):
     with stack_depth_context:
         handle_alert_unload()
         handle_form_unload()
-        load_template(url_pattern)
+        template_info = load_template(url_pattern)
         url_args = {
             "url_hash": url_hash,
             "url_pattern": url_pattern,
@@ -93,7 +117,9 @@ def navigate(url_hash=None, url_pattern=None, url_dict=None, **properties):
         clear_container()
         form = _cache.get(url_hash)
         if form is None:
-            form = get_form_to_add(url_hash, url_pattern, url_dict, properties)
+            form = get_form_to_add(
+                template_info, url_hash, url_pattern, url_dict, properties
+            )
         else:
             logger.debug(f"{form.__class__.__name__!r} loading from cache")
         _current_form = form
@@ -129,7 +155,8 @@ def load_template(url_hash):
         raise NavigationExit  # not using templates
 
     logger.debug("Checking routing templates")
-    for cls, path, condition in chain.from_iterable(_ordered_templates.values()):
+    for template_info in chain.from_iterable(_ordered_templates.values()):
+        cls, path, condition = template_info
         if not url_hash.startswith(path):
             continue
         if condition is None:
@@ -140,6 +167,7 @@ def load_template(url_hash):
         load_error_or_raise(f"No template for {url_hash!r}")
     if current_cls is cls:
         logger.debug(f"{cls.__name__!r} routing template unchanged")
+        return template_info
     else:
         logger.debug(
             f"{current_cls.__name__!r} routing template changed to {cls.__name__!r}, exiting this navigation call"
@@ -163,9 +191,9 @@ def clear_container():
     get_open_form().content_panel.clear()
 
 
-def get_form_to_add(url_hash, url_pattern, url_dict, properties):
+def get_form_to_add(template_info, url_hash, url_pattern, url_dict, properties):
     global _current_form
-    path, dynamic_vars = path_matcher(url_hash, url_pattern, url_dict)
+    path, dynamic_vars = path_matcher(template_info, url_hash, url_pattern, url_dict)
     form = path.form.__new__(path.form, **properties)
     logger.debug(f"adding {form.__class__.__name__!r} to cache")
     _current_form = _cache[url_hash] = form
@@ -196,11 +224,13 @@ def load_error_or_raise(msg):
         raise LookupError(msg)
 
 
-def path_matcher(url_hash, url_pattern, url_dict):
+def path_matcher(template_info, url_hash, url_pattern, url_dict):
     given_parts = url_pattern.split("/")
     num_given_parts = len(given_parts)
 
-    for route_info in _routes:
+    valid_routes = _routes.get(template_info.form.__name__, []) + _routes.get(None, [])
+
+    for route_info in valid_routes:
         if num_given_parts != len(route_info.url_parts):
             # url pattern CANNOT fit, skip deformatting
             continue
@@ -216,7 +246,8 @@ def path_matcher(url_hash, url_pattern, url_dict):
                 return route_info, dynamic_vars
 
     logger.debug(
-        f"no route form with:\n\turl_pattern={url_pattern!r}\n\turl_keys={list(url_dict.keys())}\n"
+        f"no route form with:\n\turl_pattern={url_pattern!r}\n\turl_keys={list(url_dict.keys())}"
+        f"\n\ttemplate={template_info.form.__name__!r}\n"
         "If this is unexpected perhaps you haven't imported the form correctly"
     )
     load_error_or_raise(f"{url_hash!r} does not exist")
@@ -277,7 +308,8 @@ def add_route_info(route_info):
             **route_info._asdict()
         )
     )
-    _routes.append(route_info)
+    for template in route_info.templates:
+        _routes.setdefault(template, []).append(route_info)
 
 
 def add_template_info(cls, priority, template_info):


### PR DESCRIPTION
close #293 

@jshaffstall - wanna have a look here?

It implements almost the API we talked about.

The only difference is that a cached form is bound to both the url hash and the name of the current template
Which means that if route form can be used by multiple templates it will be a new route form per template
Implementing that was too much to think about.

It adds the `template` as a possible argument to the `route` decorator
`template` can be a string or an iterable of strings (defaults to None, meaning I can be used by any template).

When we check the cache we check the cache against the url_hash and the current template's name.
When loading a route form if the route url_pattern does not start with the template's path argument, we prepend the path argument to the route form's url_pattern.

```python
@template("accounts", ...)
class AccountsRouter:
    ...

@tempate("admin", ...)
class AdminRouter:
    ...

@route("/forms", template=["AccountsRouter", "AdminRouter"], ...)
class FormsRoute:
    ...
```

---

**Changing _router.launch() in the template init**

I wasn't totally happy with using a `setTimeout` in the template init method.
This makes things asynchronous.

Instead I move the `_router.launch()` to the first show event.
I think is better.
It means that things run synchronously while maintaining the ability for the template to change the url_hash within its init method.

---

**Mitigating against breaking the shape of the underlying `_cache`**

The cache used to look like:
```python
>>> _cache
{"": <HomeForm object>, ...}
```

But now looks like:
```python
>>> _cache
{("", "MainForm"): <HomeForm object>, ...}
```

I've made this as not breaking as possible by implementing the `_cache` object as a subclass of dict
```python
>>> type(_cache)
_Cache
>>> remove_from_cache("")
>>> _cache
{}
# if removing a string the cache will combine the string with the name of the open_form
# equivalent to _cache.pop(("", type(get_open_form()).__name__), None)
```
similarly adding a url_hash to the cache will combine the string with the name of the open form
```python
>>> add_to_cache("", <NotHomeForm object>)
>>> _cache
{("", "MainForm"): <NotHomeForm object>, ...}
```

Technically if someone is really doing some funny stuff with the `_cache` object by doing
```python
>>> cache = routing.get_cache()
# now directly manipulate the cache
```
It could break for them - but they'd have to really try to manipulate the cache object.
And the docs clearly state
`"Adjusting the cache directly may have side effects."`

---

**TODO:**
- [x] document these changes