### PR TITLE
Routing - add a redirect argument to templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 * routing -  a template argument was added to the `@routing.route` decorator.
   This argument determines which templates a route can be added to.
   https://github.com/anvilistas/anvil-extras/issues/293
+* routing - templates can take a redirect url_hash argument,
+  if the condition() fails on a template routing will redirect to this url_hash if present
+  https://github.com/anvilistas/anvil-extras/issues/295
 
 
 # v2.0.1 16-Mar-2022

--- a/client_code/routing/_decorators.py
+++ b/client_code/routing/_decorators.py
@@ -13,16 +13,18 @@ from ._utils import RouteInfo, TemplateInfo
 __version__ = "2.0.1"
 
 
-def template(path="", priority=0, condition=None):
+def template(path="", priority=0, condition=None, redirect=None):
     if not isinstance(path, str):
         raise TypeError("the first argument to template must be a str")
     if not isinstance(priority, int):
         raise TypeError("the template priority must be an int")
     if condition is not None and not callable(condition):
         raise TypeError("the condition must be None or a callable")
+    if redirect is not None and not isinstance(redirect, str):
+        raise TypeError("redirect must be set to a str")
 
     def template_wrapper(cls):
-        info = TemplateInfo(cls, path, condition)
+        info = TemplateInfo(cls, path, condition, redirect)
         _router.add_template_info(cls, priority, info)
 
         cls_init = cls.__init__

--- a/client_code/routing/_utils.py
+++ b/client_code/routing/_utils.py
@@ -103,7 +103,7 @@ _RouteInfoBase = namedtuple(
     ["form", "templates", "url_pattern", "url_keys", "title", "fwr", "url_parts"],
 )
 
-TemplateInfo = namedtuple("template_info", ["form", "path", "condition"])
+TemplateInfo = namedtuple("template_info", ["form", "path", "condition", "redirect"])
 
 
 class RouteInfo(_RouteInfoBase):


### PR DESCRIPTION
@jshaffstall - take a look - what do you think?

There's a choice about how the redirect should work
I went with 

```python
            set_url_hash(
                redirect, replace_current_url=True, set_in_history=False, redirect=True
            )
```
But I could see an argument for `set_in_history=True`.

