### PR TITLE
Template paths and redirects

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
           # these are errors that will be ignored by flake8
           # check out their meaning here
           # https://flake8.pycqa.org/en/latest/user/error-codes.html
-          - "--ignore=E203,E266,E501,W503,F403,F401,E402"
+          - "--ignore=E203,E266,E501,W503,F403,F401,E402,F811"
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.13
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Unreleased
 
 ## Features
-* routing -  a template argument was added to the `@routing.route` decorator.
+* routing - a template argument was added to the `@routing.route` decorator.
   This argument determines which templates a route can be added to.
   https://github.com/anvilistas/anvil-extras/issues/293
+* routing - a tempalate can take multiple paths `@routing.template(path=["admin", "user"])`
+  https://github.com/anvilistas/anvil-extras/pull/298
+* routing - `@routing.redirect()` decorator added
+  https://github.com/anvilistas/anvil-extras/pull/298
+
 
 
 # v2.0.1 16-Mar-2022

--- a/client_code/routing/__init__.py
+++ b/client_code/routing/__init__.py
@@ -158,7 +158,7 @@ def set_url_hash(
         url_hash == get_url_hash()
         and url_hash in _r._cache
         and _r._current_form is not None
-    ) or _r.navigation_context.is_current_context(url_hash):
+    ) or _r.navigation_context.matches_current_context(url_hash):
         return  # should not continue if url_hash is identical to the addressbar hash!
         # but do continue if the url_hash is not in the cache i.e it was manually removed
 

--- a/client_code/routing/__init__.py
+++ b/client_code/routing/__init__.py
@@ -66,7 +66,7 @@ def on_session_expired(reload_hash=True, allow_cancel=True):
 
 def set_warning_before_app_unload(warning=True):
     """set a warning message before someone tries to navigate away from the app"""
-    logger.debug(f"Setting warning before app unload set to: {warning}")
+    logger.debug(f"setting warning before app unload set to: {warning!r}")
 
     def beforeunload(e):
         e.preventDefault()  # cancel the event
@@ -80,9 +80,10 @@ def remove_from_cache(url_hash=None, *, url_pattern=None, url_dict=None):
     gotcha: cannot be called from the init function of the the same form in cache
     because the form has not been added to the cache until it has loaded - try putthing it in the form show even instead
     """
-    url_hash = _process_url_arguments(
+    url_args = _process_url_arguments(
         url_hash, url_pattern=url_pattern, url_dict=url_dict
-    )[0]
+    )
+    url_hash = url_args[0]
     logger.debug(f"removing {url_hash!r} from cache")
     cached = _r._cache.pop(url_hash, None)
     if cached is None:

--- a/client_code/routing/__init__.py
+++ b/client_code/routing/__init__.py
@@ -157,11 +157,13 @@ def set_url_hash(
     if not load_from_cache:
         remove_from_cache(url_hash)
 
+    contexts = _r.navigation_context.contexts
+    context_hash = None if not contexts else contexts[-1].url_hash
     if (
         url_hash == get_url_hash()
         and url_hash in _r._cache
         and _r._current_form is not None
-    ):
+    ) or context_hash == url_hash:
         return  # should not continue if url_hash is identical to the addressbar hash!
         # but do continue if the url_hash is not in the cache i.e it was manually removed
 

--- a/client_code/routing/__init__.py
+++ b/client_code/routing/__init__.py
@@ -33,9 +33,8 @@ def reload_page(hard=False):
         logger.debug("hard reload_page called")
         _w.location.reload()
     else:
-        logger.debug(
-            "reload_page called, clearing the cache for this page and reloading"
-        )
+        msg = "reload_page called, clearing the cache for this page and reloading"
+        logger.debug(msg)
         url_hash, url_pattern, url_dict = get_url_components()
         remove_from_cache(url_hash)
         _r.navigate(url_hash, url_pattern, url_dict)
@@ -80,16 +79,14 @@ def remove_from_cache(url_hash=None, *, url_pattern=None, url_dict=None):
     gotcha: cannot be called from the init function of the the same form in cache
     because the form has not been added to the cache until it has loaded - try putthing it in the form show even instead
     """
-    url_args = _process_url_arguments(
+    url_hash = _process_url_arguments(
         url_hash, url_pattern=url_pattern, url_dict=url_dict
-    )
-    url_hash = url_args[0]
+    )[0]
     logger.debug(f"removing {url_hash!r} from cache")
     cached = _r._cache.pop(url_hash, None)
     if cached is None:
-        logger.debug(
-            f"*warning* {url_hash!r} was not found in cache - maybe the form was yet to load"
-        )
+        msg = f"*warning* {url_hash!r} was not found in cache - maybe the form was yet to load"
+        logger.debug(msg)
 
 
 def get_cache():
@@ -168,26 +165,22 @@ def set_url_hash(
         # but do continue if the url_hash is not in the cache i.e it was manually removed
 
     if set_in_history and not replace_current_url:
-        logger.debug(
-            f"setting url_hash to: '#{url_hash}', adding to top of history stack"
-        )
+        msg = f"setting url_hash to: '#{url_hash}', adding to top of history stack"
         _navigation.pushState(url_hash)
     elif set_in_history and replace_current_url:
-        logger.debug(
-            f"setting url_hash to: '#{url_hash}', replacing current_url, setting in history"
-        )
+        msg = f"setting url_hash to: '#{url_hash}', replacing current_url, setting in history"
         _navigation.replaceState(url_hash)
     elif not set_in_history and replace_current_url:
-        logger.debug(
-            f"setting url_hash to: '#{url_hash}', replacing current_url, NOT setting in history"
-        )
+        msg = f"setting url_hash to: '#{url_hash}', replacing current_url, NOT setting in history"
         _navigation.replaceUrlNotState(url_hash)
+    logger.debug(msg)
 
     if redirect:
-        _r.navigate(url_hash, url_pattern, url_dict, **properties)
-    elif set_in_history and _r._current_form:
+        return _r.navigate(url_hash, url_pattern, url_dict, **properties)
+    if set_in_history and _r._current_form is not None:
         _r._cache[url_hash] = _r._current_form
         # no need to add to cache if not being set in history
+    logger.debug("navigation not triggered, redirect=False")
 
 
 def load_form(*args, **kws):

--- a/client_code/routing/__init__.py
+++ b/client_code/routing/__init__.py
@@ -154,13 +154,11 @@ def set_url_hash(
     if not load_from_cache:
         remove_from_cache(url_hash)
 
-    contexts = _r.navigation_context.contexts
-    context_hash = None if not contexts else contexts[-1].url_hash
     if (
         url_hash == get_url_hash()
         and url_hash in _r._cache
         and _r._current_form is not None
-    ) or context_hash == url_hash:
+    ) or _r.navigation_context.is_current_context(url_hash):
         return  # should not continue if url_hash is identical to the addressbar hash!
         # but do continue if the url_hash is not in the cache i.e it was manually removed
 

--- a/client_code/routing/__init__.py
+++ b/client_code/routing/__init__.py
@@ -11,7 +11,7 @@ from anvil.js import window as _w
 
 from . import _navigation
 from . import _router as _r
-from ._decorators import error_form, route, template
+from ._decorators import error_form, redirect, route, template
 from ._logging import logger
 from ._router import NavigationExit, launch
 from ._utils import (

--- a/client_code/routing/_decorators.py
+++ b/client_code/routing/_decorators.py
@@ -8,22 +8,38 @@
 from functools import wraps
 
 from . import _router
-from ._utils import RouteInfo, TemplateInfo
+from ._utils import RedirectInfo, RouteInfo, TemplateInfo
 
 __version__ = "2.0.1"
 
 
-def template(path="", priority=0, condition=None):
-    if not isinstance(path, str):
-        raise TypeError("the first argument to template must be a str")
+def _check_types_common(priority, condition):
     if not isinstance(priority, int):
         raise TypeError("the template priority must be an int")
     if condition is not None and not callable(condition):
         raise TypeError("the condition must be None or a callable")
 
+
+def _make_frozen_set(obj, attr):
+    if isinstance(obj, str):
+        return frozenset((obj,))
+    rv = set()
+    for o in obj:
+        if not isinstance(o, str):
+            raise TypeError(
+                f"expected an iterable of strings or a string for {attr} argument"
+            )
+        rv.add(o)
+    return frozenset(rv)
+
+
+def template(path="", priority=0, condition=None):
+    _check_types_common(priority, condition)
+    path = _make_frozen_set(path, "path")
+
     def template_wrapper(cls):
         info = TemplateInfo(cls, path, condition)
-        _router.add_template_info(cls, priority, info)
+        _router.add_top_level_info("template", cls, priority, info)
 
         cls_init = cls.__init__
 
@@ -52,46 +68,35 @@ def template(path="", priority=0, condition=None):
     return template_wrapper
 
 
-class route:
+def redirect(path, priority=0, condition=None):
+    _check_types_common(priority, condition)
+    path = _make_frozen_set(path, "path")
+
+    def redirect_wrapper(fn):
+        info = RedirectInfo(fn, path, condition)
+        _router.add_top_level_info("redirect", redirect, priority, info)
+        return fn
+
+    return redirect_wrapper
+
+
+def route(url_pattern="", url_keys=[], title=None, full_width_row=False, template=None):
     """
     the route decorator above any form you want to load in the content_panel
     @routing.route(url_pattern=str,url_keys=List[str], title=str)
     """
+    if not isinstance(url_pattern, str):
+        raise TypeError(f"url_pattern must be type str not {type(url_pattern)}")
+    if not (title is None or isinstance(title, str)):
+        raise TypeError(f"title must be type str or None not {type(title)}")
+    url_keys = _make_frozen_set(url_keys, "url_keys")
 
-    def __init__(
-        self,
-        url_pattern="",
-        url_keys=[],
-        title=None,
-        full_width_row=False,
-        template=None,
-    ):
-        self.url_pattern = url_pattern
-        self.url_keys = url_keys
-        self.title = title
-        self.fwr = full_width_row
-        self.url_parts = []
-        self.templates = template
-
-    def validate_args(self, cls):
-        if not isinstance(self.url_pattern, str):
-            raise TypeError(
-                f"url_pattern must be type str not {type(self.url_pattern)} in {cls.__name__}"
-            )
-        if not (isinstance(self.url_keys, list) or isinstance(self.url_keys, tuple)):
-            raise TypeError(
-                f"keys should be a list or tuple not {type(self.url_keys)} in {cls.__name__}"
-            )
-        if not (self.title is None or isinstance(self.title, str)):
-            raise TypeError(
-                f"title must be type str or None not {type(self.title)} in {cls.__name__}"
-            )
-
-    def __call__(self, cls):
-        self.validate_args(cls)
-        info = RouteInfo(form=cls, **self.__dict__)
+    def route_wrapper(cls):
+        info = RouteInfo(cls, template, url_pattern, url_keys, title, full_width_row)
         _router.add_route_info(info)
         return cls
+
+    return route_wrapper
 
 
 def error_form(cls):

--- a/client_code/routing/_logging.py
+++ b/client_code/routing/_logging.py
@@ -15,9 +15,9 @@ class Logger(_Logger):
     def get_format_params(self, *, msg, **params):
         from . import _router
 
-        tabs = "  " * len(_router.navigation_context.contexts)
-        msg = msg.replace("\n", "\n" + " " * len(f"{tabs}{self.name}: "))
-        return super().get_format_params(tabs=tabs, msg=msg, **params)
+        indent = "  " * len(_router.navigation_context.contexts)
+        msg = msg.replace("\n", "\n" + " " * len(f"{indent}{self.name}: "))
+        return super().get_format_params(indent=indent, msg=msg, **params)
 
     def __setattr__(self, attr: str, value) -> None:
         if attr == "debug":  # backwards compatability
@@ -25,4 +25,4 @@ class Logger(_Logger):
         return _Logger.__setattr__(self, attr, value)
 
 
-logger = Logger("#routing", format="{tabs}{name}: {msg}", level=INFO)
+logger = Logger("#routing", format="{indent}{name}: {msg}", level=INFO)

--- a/client_code/routing/_logging.py
+++ b/client_code/routing/_logging.py
@@ -16,7 +16,7 @@ class Logger(_Logger):
         from . import _router
 
         tabs = "  " * len(_router.navigation_context.contexts)
-        msg = msg.replace("\n", "\n" + tabs)
+        msg = msg.replace("\n", "\n" + " " * len(f"{tabs}{self.name}: "))
         return super().get_format_params(tabs=tabs, msg=msg, **params)
 
     def __setattr__(self, attr: str, value) -> None:

--- a/client_code/routing/_logging.py
+++ b/client_code/routing/_logging.py
@@ -12,10 +12,17 @@ from ..logging import Logger as _Logger
 
 
 class Logger(_Logger):
+    def get_format_params(self, *, msg, **params):
+        from . import _router
+
+        tabs = "  " * len(_router.navigation_context.contexts)
+        msg = msg.replace("\n", "\n" + tabs)
+        return super().get_format_params(tabs=tabs, msg=msg, **params)
+
     def __setattr__(self, attr: str, value) -> None:
         if attr == "debug":  # backwards compatability
             return _Logger.__setattr__(self, "level", DEBUG if value else INFO)
         return _Logger.__setattr__(self, attr, value)
 
 
-logger = Logger("#routing", format="{name}: {msg}", level=INFO)
+logger = Logger("#routing", format="{tabs}{name}: {msg}", level=INFO)

--- a/client_code/routing/_router.py
+++ b/client_code/routing/_router.py
@@ -25,8 +25,9 @@ class NavigationExit(Exception):
 class navigation_context:
     contexts = []
 
-    def __init__(self):
+    def __init__(self, url_hash):
         self.stale = False
+        self.url_hash = url_hash
 
     def check_stale(self):
         assert self is self.contexts[-1]
@@ -120,7 +121,7 @@ def navigate(url_hash=None, url_pattern=None, url_dict=None, **properties):
         f"navigation triggered: url_hash={url_hash!r}, url_pattern={url_pattern!r}, url_dict={url_dict}"
     )
     global _current_form
-    with navigation_context() as nav_context:
+    with navigation_context(url_hash) as nav_context:
         handle_alert_unload()
         handle_form_unload()
         nav_context.check_stale()
@@ -190,6 +191,9 @@ def load_template_or_redirect(url_hash, nav_context: navigation_context):
             break
         redirect_hash = callable_()
         if isinstance(redirect_hash, str):
+            if redirect_hash == nav_context.url_hash:
+                continue
+
             from . import set_url_hash
 
             logger.debug(f"redirecting to url_hash: {redirect_hash!r}")

--- a/client_code/routing/_router.py
+++ b/client_code/routing/_router.py
@@ -79,6 +79,7 @@ class _Cache(dict):
     __getitem__ = _wrap_method(dict.__getitem__)
     __setitem__ = _wrap_method(dict.__setitem__)
     __delitem__ = _wrap_method(dict.__delitem__)
+    __contains__ = _wrap_method(dict.__contains__)
     get = _wrap_method(dict.get)
     pop = _wrap_method(dict.pop)
     setdefault = _wrap_method(dict.setdefault)

--- a/client_code/routing/_router.py
+++ b/client_code/routing/_router.py
@@ -35,7 +35,7 @@ class navigation_context:
 
     def __enter__(self):
         num_contexts = len(self.contexts)
-        logger.debug(f"entering navigation {num_contexts}")
+        logger.debug(f"entering navigation level: {num_contexts}")
         if not self.contexts:
             self.contexts.append(self)
         elif num_contexts <= 10:
@@ -53,7 +53,7 @@ class navigation_context:
     def __exit__(self, exc_type, *args):
         self.contexts.pop()
         num_contexts = len(self.contexts)
-        logger.debug(f"exiting navigation {num_contexts}")
+        logger.debug(f"exiting navigation level:{num_contexts}")
         if not num_contexts:
             logger.debug("navigation complete\n")
         if exc_type is NavigationExit:

--- a/client_code/routing/_router.py
+++ b/client_code/routing/_router.py
@@ -36,7 +36,11 @@ class navigation_context:
 
     @classmethod
     def is_current_context(cls, url_hash):
-        return cls.contexts and cls.contexts[-1].url_hash == url_hash
+        return (
+            cls.contexts
+            and cls.contexts[-1].url_hash == url_hash
+            and _current_form is not None
+        )
 
     def __enter__(self):
         num_contexts = len(self.contexts)

--- a/client_code/routing/_utils.py
+++ b/client_code/routing/_utils.py
@@ -22,6 +22,9 @@ def get_url_components(url_hash=None):
     if url_hash is None:
         # url_hash = anvil.get_url_hash()  #changed since anvil decodes the url_hash
         url_hash = location.hash[1:]  # without the hash
+    elif isinstance(url_hash, str):
+        url_hash = url_hash if not url_hash.startswith("#") else url_hash[1:]
+
     if isinstance(url_hash, dict):
         # this is the case when anvil converts the url hash to a dict automatically
         url_pattern = ""

--- a/client_code/routing/_utils.py
+++ b/client_code/routing/_utils.py
@@ -104,6 +104,7 @@ _RouteInfoBase = namedtuple(
 )
 
 TemplateInfo = namedtuple("template_info", ["form", "path", "condition"])
+RedirectInfo = namedtuple("redirect_info", ["redirect", "path", "condition"])
 
 
 class RouteInfo(_RouteInfoBase):


### PR DESCRIPTION
@jshaffstall 

attempt number 2.

Maybe you could have a play with it by cloning this version of anvil-extras:
https://anvil.works/build#clone:6ATPRINDTZUXBKSQ=R3XKGGOVQZK6MZVHG36HCTLU

Then changing the dependency to the local copy while we still work out the kinks.

I changed a bunch of logging statements as I was working on it to make it easier to see what was going on.

The api is the one we came up with on the other branch:

```python
@routing.redirect(...) # same args as template
def redirect_no_admin():
    # routing.set_url_hash("login", ...)
    # or return a url_hash
    return "login"

```

