### PR TITLE
routing - adjust alert handler

### DIFF
--- a/client_code/routing/_alert.py
+++ b/client_code/routing/_alert.py
@@ -9,24 +9,26 @@ __version__ = "2.0.1"
 
 from anvil.js.window import jQuery as _S
 
-alert_modal = _S("#alert-modal")
-
 
 def handle_alert_unload() -> bool:
     """
     if there is an active alert which is not dismissible then navigation is prevented
     return value indicates whether this function took control of the on_navigation
     """
-    data = alert_modal.data("bs.modal")
-    if data is None:
-        return False
-    elif not data.isShown:
-        return False
-    elif data.options and data.options.backdrop != "static":
-        # bootstrap alerts have a backdrom of static when not dismissible
-        alert_modal.modal("hide")
-        return False
-    from . import _navigation
+    current_alerts = _S(".modal")
+    for alert_modal in current_alerts:
+        alert_modal = _S(alert_modal)
+        data = alert_modal.data("bs.modal")
+        if data is None:
+            continue
+        elif not data.isShown:
+            continue
+        elif data.options and data.options.backdrop != "static":
+            # bootstrap alerts have a backdrop of static when not dismissible
+            alert_modal.modal("hide")
+        else:
+            from . import _navigation
 
-    _navigation.stopUnload()
-    return True
+            _navigation.stopUnload()
+            return True
+    return False


### PR DESCRIPTION
support all of anvil alerts/modals that might possibly be open

This includes the stripe modal, google login modal etc

When anvil supports multiple alerts this will also just work.