### PR TITLE
Auto Refreshing Proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+## Notable Change
+* `@auto_refreshing` - the original item will now be proxied rather than copied.
+  Changes to the proxied item will make changes to the original item.
+  https://github.com/anvilistas/anvil-extras/pull/311
+
 ## New Features
 * routing - a template argument was added to the `@routing.route` decorator.
   This argument determines which templates a route can be added to.
@@ -18,6 +23,8 @@
 ## Bug Fixes
 * `MultiSelectDropDown`: fix change event should only fire on user interaction
   https://github.com/anvilistas/anvil-extras/issues/307
+* `@auto_refreshing`: support auto_refreshing when the item is not explicitly set
+  https://github.com/anvilistas/anvil-extras/issues/250
 
 
 # v2.0.1 16-Mar-2022

--- a/client_code/Demo/__init__.py
+++ b/client_code/Demo/__init__.py
@@ -28,7 +28,7 @@ class Demo(DemoTemplate):
             chips=["a", "b", "c"],
             text="",
         )
-        self.item = self.default_item
+        self.item = self.default_item.copy()
         self.pivot.items = anvil.http.request(dataset_url, json=True)
         self.init_components(**properties)
 
@@ -48,7 +48,7 @@ class Demo(DemoTemplate):
         self.item["counter"] += 1
 
     def reset_button_click(self, **event_args):
-        self.item = self.default_item
+        self.item = self.default_item.copy()
 
     ###### MULTI SELECT ######
     def multi_select_drop_down_1_change(self, **event_args):

--- a/client_code/utils/__init__.py
+++ b/client_code/utils/__init__.py
@@ -14,7 +14,7 @@ __version__ = "2.0.1"
 def __dir__():
     return [
         "auto_refreshing",
-        "BindingRefreshDict",
+        "ProxyItem",
         "correct_canvas_resolution",
         "import_module",
         "timed",
@@ -56,6 +56,7 @@ def import_module(name, package=None):
 _imports = {
     "auto_refreshing": "._auto_refreshing",
     "BindingRefreshDict": "._auto_refreshing",
+    "ProxyItem": "._auto_refreshing",
     "correct_canvas_resolution": "._canvas_helpers",
     "timed": "._timed",
     "wait_for_writeback": "._writeback_waiter",

--- a/client_code/utils/_auto_refreshing.py
+++ b/client_code/utils/_auto_refreshing.py
@@ -6,28 +6,96 @@
 # This software is published at https://github.com/anvilistas/anvil-extras
 
 
-from functools import cache
+from functools import lru_cache
+
+from anvil.server import portable_class
 
 __version__ = "2.0.1"
 
-_dict_setitem = dict.__setitem__
+
+def wrap_method(meth_name, refresh=False):
+    def wrapped(self, *args, **kws):
+        rv = getattr(self._obj, meth_name)
+        if rv is not None:
+            rv = rv(*args, **kws)
+        if refresh:
+            self._refresh_data_bindings()
+        return rv
+
+    wrapped.__name__ = meth_name
+    wrapped.__qualname__ = "ProxyItem." + meth_name
+    return wrapped
 
 
-class BindingRefreshDict(dict):
-    """A dict that calls refresh_data_bindings when its content changes"""
+@portable_class
+class ProxyItem:
+    """A proxy that calls refresh_data_bindings when the underlying item changes"""
+
+    __slots__ = {"_obj", "_forms"}
+
+    def __init__(self, obj):
+        self._obj = obj
 
     def _refresh_data_bindings(self):
         forms = getattr(self, "_forms", [])
         for form in forms:
             form.refresh_data_bindings()
 
-    def __setitem__(self, key, value):
-        _dict_setitem(self, key, value)
-        self._refresh_data_bindings()
+    __getitem__ = wrap_method("__getitem__")
+    __setitem__ = wrap_method("__setitem__", True)
+    __delitem__ = wrap_method("__delitem__", True)
+    get = wrap_method("get")
+    update = wrap_method("update", True)
+    pop = wrap_method("pop", True)
+    clear = wrap_method("clear", True)
+    keys = wrap_method("keys")
+    values = wrap_method("values")
+    items = wrap_method("items")
+    __eq__ = wrap_method("__eq__")
+    __hash__ = wrap_method("__hash__")
+    __iter__ = wrap_method("__iter__")
+    __contains__ = wrap_method("__contains__")
+    __len__ = wrap_method("__len__")
 
-    def update(self, *args, **kwargs):
-        super().update(*args, **kwargs)
+    def __setattr__(self, attr: str, val) -> None:
+        if attr in self.__slots__:
+            return object.__setattr__(self, attr, val)
+        rv = setattr(self._obj, attr, val)
         self._refresh_data_bindings()
+        return rv
+
+    def __getattr__(self, attr):
+        return getattr(self._obj, attr)
+
+    def __repr__(self):
+        return f"proxy_item({self._obj!r})"
+
+    def __serialize__(self, info):
+        return self._obj
+
+    @staticmethod
+    def __new_deserialized__(obj, info):
+        return obj
+
+
+# Backwards Compatability
+BindingRefreshDict = ProxyItem
+
+
+def _mk_init_components(cls):
+    """Generate a method to override a form's 'init_components' method"""
+    super_init = super(cls, cls).init_components
+
+    def init_components(self, item=None, **props):
+        if item is not None:
+            return super_init(self, item=item, **props)
+        elif self.item == {}:
+            return super_init(self, item={}, **props)
+        else:
+            # don't provide the item if we've already set one
+            return super_init(self, **props)
+
+    return init_components
 
 
 def _item_override(cls):
@@ -38,9 +106,7 @@ def _item_override(cls):
         return base_item.__get__(self, cls)
 
     def item_setter(self, item):
-        item = (
-            item if isinstance(item, BindingRefreshDict) else BindingRefreshDict(item)
-        )
+        item = item if isinstance(item, ProxyItem) else ProxyItem(item)
         # use a set here so that subforms using the same item can also trigger
         # refresh_data_bindings
         forms = item._forms = getattr(item, "_forms", set())
@@ -50,8 +116,9 @@ def _item_override(cls):
     return property(item_getter, item_setter)
 
 
-@cache
+@lru_cache(maxsize=None)
 def auto_refreshing(cls):
     """A decorator for a form class to refresh data bindings automatically"""
     cls.item = _item_override(cls)
+    cls.init_components = _mk_init_components(cls)
     return cls

--- a/docs/guides/modules/utils.rst
+++ b/docs/guides/modules/utils.rst
@@ -118,19 +118,14 @@ To use it, import the decorator and apply it to the class for a form:
        def __init__(self, **properties):
            self.init_components(**properties)
 
-Now, the form has an ``item`` property which behaves like a dictionary. Whenever a value of that dictionary changes, the form's ``refresh_data_bindings`` method will be called.
+The form's ``item`` property will be proxied.
 
-Note: The ``item`` property will no longer reference the same object. Rather, in the following example, it is as though auto-refresh adds the ``item = dict(item)`` line:
+If your original item was a dictionary, whenever a value of the proxied item changes,
+the form's ``refresh_data_bindings`` method will be called.
 
-.. code-block:: python
+Note that the proxied item will make changes to the original ``item``.
 
-   other_item = {"x": 1}
-   item = other_item
-
-   item = dict(item)
-   item["x"] = 2
-
-As in the above code, with auto-refresh, ``item`` is changed but ``other_item`` is not.
+It shouldn't matter what the original ``item`` is. It could be a dictionary, app_table Row or some other obsucre object.
 
 
 Wait for writeback


### PR DESCRIPTION
Just an idea which I quite like
it's potentially breaking - though I think we can get away with a minor release.

Instead of subclassing from dict - we proxy the original item object.
Changes to the proxied item will call auto_refreshing and also update the original item object.

This means that we can do `auto_refreshing` on any object.
We expect a dictionary or anvil table row, but most sensible substitutes for an `item` would work just fine.

Sending the item to the server will just send the original item.
_(I changed to `lru_cache` because `cache` is not available on the server for when the class is portable)_

referencing #89 
closes #250 


@hugetim, @rhurlbatt - you might be interested in this one since we've talked about it before

