### PR TITLE
Add workflow for release

### DIFF
--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -1,9 +1,8 @@
-
-name: release
+name: merge_to_main
 
 on:
   push:
-    tags: ['v*']
+    branches: [main]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -21,12 +20,12 @@ jobs:
           chmod 600 /home/runner/.ssh/github_actions
           ssh-agent -a $SSH_AUTH_SOCK > /dev/null
           ssh-add /home/runner/.ssh/github_actions
-      - name: Deploy to production published
+      - name: Deploy to production master
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         run: |
           git config --global user.name "GitHubActions"
           git config --global user.email "actions@github.com"
           git remote add anvil "${{ secrets.ANVIL_REPO_URL }}"
-          git push anvil main:published --force
+          git push anvil main:master --force
           git push --tags anvil


### PR DESCRIPTION
Change the name of the previous 'release' workflow to 'merge_to_main'
This pushes to the production master branch whenever the main branch is updated. No change to its content.

Add a new 'release' workflow.
This pushes to the production published branch when a new tag matching the pattern 'v*' is pushed to github.

(Also, my shiny new local yamlls lsp server reformatted some of the yaml as it didn't like the indentation).