### PR TITLE
MultiSelectDropDown: fix properties should be dynamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 ## Bug fixes
 * `augment` - DataGrid's pagination click event prevented other events from being added
   https://github.com/anvilistas/anvil-extras/pull/325
+* `MultiSelectDropDown` - all properties are now dynamic and can be updated in code
+  https://github.com/anvilistas/anvil-extras/pull/331
+
 
 ## Bug Fixes
 * `popovers` fix bug scrolling on mobile


### PR DESCRIPTION
Fixes multi select drop down properties should be dynamic
Things like `enable_select_all`, `placeholder` and friends.

Some minor house keeping.

---

@Duncanr-glitch
Do you wanna rebase on this branch?
Let me know if you're not sure how to do that and I'll give you some incantations