### PR TITLE
routing: adjust routing.ANY to be combined with required keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
   https://github.com/anvilistas/anvil-extras/discussions/319
 * `augment` adjust handling of RadioButton to work correctly with the augment module
   https://github.com/anvilistas/anvil-extras/pull/325
-* `routing` - to catch arbirtrary query params in a route use `url_keys=routing.ANY`
+* `routing` - to catch arbirtrary query params in a route use `url_keys=[routing.ANY]`
   https://github.com/anvilistas/anvil-extras/issues/342
 
 ## Bug fixes

--- a/client_code/routing/_router.py
+++ b/client_code/routing/_router.py
@@ -324,7 +324,15 @@ def path_matcher(template_info, init_path, url_hash, url_pattern, url_dict):
             elif url_part != given:
                 break
         else:  # no break
-            if set(url_dict) == route_info.url_keys or route_info.url_keys is ANY:
+            # rely on dict.keys() being set like
+            url_keys = url_dict.keys()
+            route_keys = route_info.url_keys
+            if url_keys == route_keys:
+                return route_info, dynamic_vars
+            if ANY not in route_keys:
+                continue
+            route_keys -= {ANY}  # route_keys is a frozen set
+            if route_keys.issubset(url_keys):
                 return route_info, dynamic_vars
 
     logger.debug(

--- a/client_code/routing/_utils.py
+++ b/client_code/routing/_utils.py
@@ -105,13 +105,11 @@ def _get_url_hash(url_pattern, url_dict):
 
 
 def _as_frozen_str_iterable(obj, attr, allow_none=False, factory=frozenset):
-    if isinstance(obj, str) or (allow_none and obj is None):
+    if isinstance(obj, str) or (allow_none and obj is None) or obj is ANY:
         return factory([obj])
-    if obj is ANY:
-        return obj
     rv = []
     for o in obj:
-        if not isinstance(o, str):
+        if not isinstance(o, str) and obj is not ANY:
             msg = f"expected an iterable of strings or a string for {attr} argument"
             raise TypeError(msg)
         rv.append(o)

--- a/docs/guides/modules/routing.rst
+++ b/docs/guides/modules/routing.rst
@@ -726,7 +726,8 @@ This is the correct way:
         #routing provides self.url_dict
 
 
-If you need a catch all for arbirtrary url_keys use ``url_keys=routing.ANY``.
+If you need a catch all for arbirtrary url_keys use ``url_keys=[routing.ANY]``.
+Or combine ``routing.ANY`` with required keys ``url_keys=["search", routing.ANY]``.
 
 
 Template Form Callbacks


### PR DESCRIPTION
Adjusts the implementation so that it can be a catch all, or be part of url keys with some required values

address #342 

