### PR TITLE
routing: fix alerts no longer block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+## Bug Fixes
+* routing was no longer dismissing alerts on navigation
+  you will now need to use `routing.alert` in place of `anvil.alert` for an alert to be dismissed on navigation
+  non-dismissible alerts will block the navigation
+  https://github.com/anvilistas/anvil-extras/pull/437
+
 # v2.4.0 14-Jun-2023
 
 ## New Features

--- a/client_code/routing/__init__.py
+++ b/client_code/routing/__init__.py
@@ -11,6 +11,7 @@ from anvil.js import window as _w
 
 from . import _navigation
 from . import _router as _r
+from ._alert import alert
 from ._decorators import error_form, redirect, route, template
 from ._logging import logger
 from ._router import NavigationExit, launch

--- a/client_code/routing/_alert.py
+++ b/client_code/routing/_alert.py
@@ -13,7 +13,7 @@ active_alerts = []
 
 
 def handle_alert_unload() -> bool:
-    for alert in active_alerts:
+    for alert in reversed(active_alerts):
         if alert.blocking:
             from . import _navigation
 

--- a/docs/guides/modules/routing.rst
+++ b/docs/guides/modules/routing.rst
@@ -449,6 +449,14 @@ List of Methods
     Note that any additional properties will only be passed to a form
     if it is the first time the form has loaded and/or it is **not** loaded from cache.
 
+.. function:: routing.alert(content, *args, **kws)
+
+    Use in place of ``anvil.alert``. If you use ``anvil.alert`` then alerts will not close when the user navigates.
+    This is probably not what you want. When using ``routing.alert`` any alert that is ``dismissible`` will close when the user navigates.
+    Any non-dismissible alert will block the navigation.
+
+    You may want to do ``import anvil; anvil.alert = routing.alert`` as the first line in a startup module to override ``anvil.alert`` across your app.
+
 
 .. function:: routing.get_url_components(url_hash=None)
 


### PR DESCRIPTION
This PR fixes alerts 
The previous implementation relied on knowing that alerts were bootstrap alerts
This is no longer the case
Instead it provides a `routing.alert`, which wraps `anvil.alert`

The behaviour is as before, dismissible alerts with close, non-dismissible alerts will block

