### PR TITLE
Lazy route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## New Features
+* `routing.lazy_route` - allows you to lazily load Forms whilst using routing
+  https://github.com/anvilistas/anvil-extras/pull/442
+
 ## Bug Fixes
 * routing was no longer dismissing alerts on navigation
   you will now need to use `routing.alert` in place of `anvil.alert` for an alert to be dismissed on navigation

--- a/client_code/routing/__init__.py
+++ b/client_code/routing/__init__.py
@@ -12,7 +12,7 @@ from anvil.js import window as _w
 from . import _navigation
 from . import _router as _r
 from ._alert import alert
-from ._decorators import error_form, redirect, route, template
+from ._decorators import error_form, lazy_route, redirect, route, template
 from ._logging import logger
 from ._router import NavigationExit, launch
 from ._utils import (

--- a/client_code/routing/_decorators.py
+++ b/client_code/routing/_decorators.py
@@ -106,6 +106,7 @@ def lazy_route(
                 form_class = fn()
                 return form_class.__new__(form_class, **properties)
 
-        return route_wrapper(Lazy)
+        route_wrapper(Lazy)
+        return fn
 
     return wrapper

--- a/client_code/routing/_decorators.py
+++ b/client_code/routing/_decorators.py
@@ -93,3 +93,19 @@ def error_form(cls):
     cls._route_props = {"title": None, "layout_props": {}}
     _router._error_form = cls
     return cls
+
+
+def lazy_route(
+    url_pattern="", url_keys=[], title=None, full_width_row=False, template=None
+):
+    route_wrapper = route(url_pattern, url_keys, title, full_width_row, template)
+
+    def wrapper(fn):
+        class Lazy:
+            def __new__(cls, **properties):
+                form_class = fn()
+                return form_class.__new__(form_class, **properties)
+
+        return route_wrapper(Lazy)
+
+    return wrapper

--- a/client_code/routing/_decorators.py
+++ b/client_code/routing/_decorators.py
@@ -102,8 +102,12 @@ def lazy_route(
 
     def wrapper(fn):
         class Lazy:
+            _form = None
+
             def __new__(cls, **properties):
-                form_class = fn()
+                form_class = cls._form
+                if form_class is None:
+                    form_class = cls._form = fn()
                 return form_class.__new__(form_class, **properties)
 
         route_wrapper(Lazy)

--- a/docs/guides/modules/routing.rst
+++ b/docs/guides/modules/routing.rst
@@ -400,7 +400,7 @@ Decorators
             from ..ArticleForm import ArticleForm
             return ArticleForm
 
-    This decorator allows you to lazyily load Forms. When using ``@routing.route`` all Forms that are routes must be imported before the app starts.
+    This decorator allows you to lazily load Forms. When using ``@routing.route`` all Forms that are routes must be imported before the app starts.
     This is fine for most small applications, but as your application grows you may find that executing all the code for all the Forms is slow.
     The ``lazy_route`` decorator should decorate a function that imports the Form and returns it.
 

--- a/docs/guides/modules/routing.rst
+++ b/docs/guides/modules/routing.rst
@@ -389,6 +389,22 @@ Decorators
         If the ``before_unload`` method is added it will be called whenever the form currently in the ``content_panel`` is about to be removed.
         If any truthy value is returned then unloading will be prevented. See `Form Unloading <#form-unloading>`__.
 
+.. function:: routing.lazy_route(url_pattern, url_keys=[], title=None, full_width_row=False, template=None)
+
+    .. code:: python
+
+        from anvil_extras import routing
+
+        @routing.lazy_route('article', url_keys=['id', routing.ANY], title="Article-{id} | RoutingExample")
+        def article_route():
+            from ..ArticleForm import ArticleForm
+            return ArticleForm
+
+    This decorator allows you to lazyily load Forms. When using ``@routing.route`` all Forms that are routes must be imported before the app starts.
+    This is fine for most small applications, but as your application grows you may find that executing all the code for all the Forms is slow.
+    The ``lazy_route`` decorator should decorate a function that imports the Form and returns it.
+
+
 .. function:: routing.redirect(path, priority=0, condition=None)
 
     The redirect decorator can decorate a function that will intercept the current navigtation, depending on its ``path``, ``priority`` and ``condition`` arguments.


### PR DESCRIPTION
tagging @steininge and @jshaffstall  who might be interested in this one following this forum post:

https://anvil.works/forum/t/lazy-loading-for-forms/18166/2

```python

@routing.lazy_route('article', url_keys=['id', routing.ANY], title="Article-{id} | RoutingExample")
def article_route():
    from ..ArticleForm import ArticleForm
    return ArticleForm
 
```