### PR TITLE
Navigation: set default mode and allow titles in menu definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
   https://github.com/anvilistas/anvil-extras/pull/442
 * Autocompletion: adds filter_mode property - either contains or startswith
   https://github.com/anvilistas/anvil-extras/discussions/444
+* navigation - ``set_mode("hash")`` can be used to set the default navigation mode to hash routing
+  https://github.com/anvilistas/anvil-extras/discussions/458
+* navigation - menu definition can include ``title``, rather than registering a form with a title
+  https://github.com/anvilistas/anvil-extras/discussions/453
 
 ## Bug Fixes
 * routing was no longer dismissing alerts on navigation

--- a/client_code/navigation.py
+++ b/client_code/navigation.py
@@ -22,9 +22,24 @@ _visibility = {}
 
 _title_label = Label()
 
+_default_mode = "classic"
+
+
+def _validate_mode(mode):
+    if mode not in ("classic", "hash"):
+        raise ValueError(
+            "A navigation link's routing must either be 'classic' or 'hash'"
+        )
+
+
+def set_mode(mode):
+    global _default_mode
+    _validate_mode(mode)
+    _default_mode = mode
+
 
 class register:
-    """A decorator to register a form in the _forms dict."""
+    """A decorator to register a form as a navigation target (only use in classic mode)"""
 
     def __init__(self, name, title=None):
         self.name = name
@@ -50,7 +65,9 @@ def set_title(text):
 def open_form(form_name, *args, full_width=False, **kwargs):
     """Use classic routing to open a registered form"""
     form = get_form(form_name, *args, **kwargs)
-    set_title(_forms[form_name]["title"])
+    title = _forms[form_name]["title"]
+    if title is not None:
+        set_title(title)
     get_open_form().content_panel.clear()
     get_open_form().content_panel.add_component(form, full_width_row=full_width)
 
@@ -75,6 +92,9 @@ def _reset_links():
             link.role = []
 
 
+_actions = {"classic": open_form, "hash": set_url_hash}
+
+
 def _default_link_click(**event_args):
     """A handler for navigation link click events
     * Clears the role of all links registered in this module
@@ -84,11 +104,13 @@ def _default_link_click(**event_args):
     _reset_links()
     link = event_args["sender"]
     link.role += ["selected"]
-    actions = {"classic": open_form, "hash": set_url_hash}
+
     kwargs = {}
     if link.tag.routing == "classic":
         kwargs["full_width"] = link.tag.full_width
-    actions[link.tag.routing](link.tag.target, **kwargs)
+    if link.tag.title is not None:
+        set_title(link.tag.title)
+    _actions[link.tag.routing](link.tag.target, **kwargs)
 
 
 def _visibility_event_handler(**event_args):
@@ -125,9 +147,10 @@ def build_menu(container, items, with_title=True):
 
 
 def navigation_link(
-    routing="classic",
+    routing=None,
     full_width=False,
     target=None,
+    title=None,
     on_click=None,
     visibility=None,
     **kwargs,
@@ -136,13 +159,13 @@ def navigation_link(
 
     Parameters
     ----------
-    routing
-      Either 'classic' or 'hash'
     full_width
       Whether the link target should open as full width
     target
       Either the name of a registered form for classic routing or
       a url_hash for hash routing
+    title
+      sets the page title when this link is clicked
     on_click
       event handler to call when clicked
     visibility
@@ -150,15 +173,15 @@ def navigation_link(
     kwargs
       will be passed the Link constructor
     """
-    if routing not in ("classic", "hash"):
-        raise ValueError(
-            "A navigation link's routing must either be 'classic' or 'hash'"
-        )
+    routing = routing or _default_mode
+    _validate_mode(routing)
+
     link = Link(**kwargs)
     link.tag.routing = routing
     link.tag.full_width = full_width
     link.tag.target = target
     link.tag.visibility = visibility
+    link.tag.title = title
     if on_click is None:
         link.set_event_handler("click", _default_link_click)
     else:

--- a/docs/guides/modules/navigation.rst
+++ b/docs/guides/modules/navigation.rst
@@ -53,7 +53,7 @@ Menu
         navigation.build_menu(self.menu_panel, menu)
         self.init_components(**properties)
 
-The above code will add 'Home' and 'About' links to the menu, which will open registered forms named with names ``"home"`` and ``"about"`` respectively.
+The above code will add 'Home' and 'About' links to the menu, which will open registered forms with names ``"home"`` and ``"about"`` respectively.
 If using ``"hash"`` mode, then the links will set the url hash to ``"home"`` and ``"about"``
 
 

--- a/docs/guides/modules/navigation.rst
+++ b/docs/guides/modules/navigation.rst
@@ -8,30 +8,29 @@ This module builds a menu of link objects based on a simple dictionary definitio
 
 Rather than manually adding links and their associated click event handlers, the module does that for you!
 
-Usage
------
 
-Forms
-+++++
+Mode
+++++
 
-In order for a form to act as a target of a menu link, it has to register a name with the navigation module using a decorator
-on its class definition. e.g. Assuming the module is installed as a dependency named 'Extras':
+There are two modes for the navigation module: ``"classic"`` and ``"hash"``.
+If using ``"classic"`` mode, when a link is clicked, a Form registered with the navigation module is added to the ``content_panel`` element of the currently open form.
+If using ``"hash"`` mode, when a link is clicked, navigation is taken care of using the routing module.
+
 
 .. code-block:: python
 
-    from ._anvil_designer import HomeTemplate
-    from anvil import *
     from anvil_extras import navigation
 
+    navigation.set_mode("hash")
+    navigation.set_mode("classic")
 
-    @navigation.register(name="home")
-    class Home(HomeTemplate):
-      def __init__(self, **properties):
-        self.init_components(**properties)
+
+``"classic"`` mode is the default mode if no mode is set.
+
 
 Menu
 ++++
-* In the Main form for your app, add a content panel to the menu on the left hand side and call it 'menu_panel'
+* In the Main form for your app, add a ``ColumnPanel`` to the menu on the left hand side and call it ``"menu_panel"``
 
 * Add a menu definition dict to the code for your Main form and pass the panel and the dict to the menu builder. e.g.
 
@@ -51,17 +50,36 @@ Menu
     class Main(MainTemplate):
 
       def __init__(self, **properties):
-        self.advanced_mode = False
         navigation.build_menu(self.menu_panel, menu)
         self.init_components(**properties)
 
-will add 'Home' and 'About' links to the menu which will open registered forms named 'home' and 'about' respectively.
+The above code will add 'Home' and 'About' links to the menu, which will open registered forms named with names ``"home"`` and ``"about"`` respectively.
+If using ``"hash"`` mode, then the links will set the url hash to ``"home"`` and ``"about"``
 
-Each item in the dict needs the 'text' and 'target' keys as a minimum. It may also include 'full_width', 'routing' and 'visibility' keys:
 
- * 'full_width' can be True or False to indicate whether the target form should be opened with 'full_width_row' or not.
- * 'routing' can be either 'classic' or 'hash' to indicate whether clicking the link should use Anvil's `add_component` function or hash routing to open the target form. Classic routing is the default if the key is not present in the menu dict.
+Registered Forms
+++++++++++++++++
+
+In ``"classic"`` mode, in order for a form to act as a target of a menu link, it has to be registered with a unique name using the ``@navigation.register()`` decorator.
+
+.. code-block:: python
+
+    from ._anvil_designer import HomeTemplate
+    from anvil_extras import navigation
+
+    @navigation.register("home")
+    class Home(HomeTemplate):
+      def __init__(self, **properties):
+        self.init_components(**properties)
+
+Menu definition
++++++++++++++++
+
+Each item in the dict needs the ``'text'`` and ``'target'`` keys as a minimum. It may also include ``'title'``, ``'full_width'`` and ``'visibility'`` keys:
+
+ * 'full_width' can be True or False to indicate whether the target form should be opened with 'full_width_row' or not. (Only valid with ``"classic"`` mode - see routing documentation for ``full_width_row`` if using ``"hash"`` mode)
  * 'visibility' can be a dict mapping an anvil event to either True or False to indicate whether the link should be made visible when that event is raised.
+ * 'title': optional, can be a string or None. Sets the page title.
 
  All other keys in the menu dict are passed to the Link constructor.
 
@@ -74,10 +92,12 @@ Each item in the dict needs the 'text' and 'target' keys as a minimum. It may al
     from anvil_extras import navigation
     from HashRouting import routing
 
+    navigation.set_mode("hash")
+
     menu = [
-      {"text": "Home", "target": "home", "icon": "fa:home"},
-      {"text": "About", "routing": "hash", "target": "about", "icon": "fa:info"},
-      {"text": "Contact", "routing": "hash", "target": "contact", "icon": "fa:envelope"},
+      {"text": "Home", "target": "home", "icon": "fa:home", "title": "Home"},
+      {"text": "About", "target": "about", "icon": "fa:info", "title": "About"},
+      {"text": "Contact", "target": "contact", "icon": "fa:envelope", "title": "Contact"},
       {
         "text": "Settings",
         "target": "settings",
@@ -85,7 +105,8 @@ Each item in the dict needs the 'text' and 'target' keys as a minimum. It may al
         "visibility": {
           "x-advanced-mode-enabled": True,
           "x-advanced-mode-disabled": False
-        }
+        },
+        "title": "Settings"
       }
     ]
 
@@ -101,7 +122,6 @@ Each item in the dict needs the 'text' and 'target' keys as a minimum. It may al
       def form_show(self, **event_args):
         self.set_advanced_mode(False)
 
-Note - since this example includes hash routing, it also requires a decorator from the `Hash Routing App <https://github.com/s-cork/HashRouting>`_ on the Main class.
 
 Startup
 +++++++
@@ -117,21 +137,11 @@ e.g. Create a module called 'startup', set it as the startup module and import y
 
    open_form(Main())
 
+
 Page Titles
 +++++++++++
-By default, the menu builder will also add a Label to the title slot of your Main form. If you register a form with a title as well as a name, the module will update that label as you navigate around your app. e.g. to add a title to the home page example:
-
-.. code-block:: python
-
-    from ._anvil_designer import HomeTemplate
-    from anvil import *
-    from anvil_extras import navigation
-
-
-    @navigation.register(name="home", title="Home")
-    class Home(HomeTemplate):
-      def __init__(self, **properties):
-        self.init_components(**properties)
+By default, the menu builder will also add a Label to the title slot of your Main form.
+Titles will be set based on the menu definition passed to ``build_menu``.
 
 If you want to disable this feature, set the `with_title` argument to `False` when you call `build_menu` in your Main form. e.g.
 
@@ -140,13 +150,12 @@ If you want to disable this feature, set the `with_title` argument to `False` wh
     class Main(MainTemplate):
 
       def __init__(self, **properties):
-        self.advanced_mode = False
         navigation.build_menu(self.menu_column_panel, menu, with_title=False)
         self.init_components(**properties)
 
 Navigate with Code
 ++++++++++++++++++
-You can emulate clicking a menu link using the go_to function, which takes a 'target' key as its only parameter, e.g.
+You can emulate clicking a menu link using the ``go_to`` function, which takes a ``'target'`` key as its only parameter, e.g.
 
 .. code-block:: python
 


### PR DESCRIPTION
close #453

Backwards compatible

- Removes docs for `"routing"` key in favour of `set_mode`
- Removes docs for `@register(name="foo", title="Foo")` in favour of `@register("foo")` and a `"title"` key in the menu definition.

