### PR TITLE
routing: tweak to force launch global

### DIFF
--- a/client_code/routing/_router.py
+++ b/client_code/routing/_router.py
@@ -112,8 +112,7 @@ def launch():
     template_instance = get_open_form()
     current_template = type(template_instance)
 
-    if template_instance is None or current_template not in _templates:
-        _force_launch = True
+    _force_launch = template_instance is None or current_template not in _templates
 
     if _queued:
         # only run the last _queued navigation


### PR DESCRIPTION
minor tweak
set `_force_launch` to `True` or `False`
just because of the way `routing.launch()` is called
the call can get a bit nested because a fresh template will also call `routing.launch` in its form_show event

i.e. one `routing.launch()` will start before a previous one has finished executing
