### PR TITLE
injecting html: cope with hot module reloading in the designer

### DIFF
--- a/client_code/utils/_component_helpers.py
+++ b/client_code/utils/_component_helpers.py
@@ -10,29 +10,38 @@ import anvil.js
 from anvil import Component as _Component
 from anvil import app as _app
 from anvil.js import get_dom_node as _get_dom_node
+from anvil.js import window
 from anvil.js.window import Promise as _Promise
 from anvil.js.window import document as _document
 
 __version__ = "2.4.0"
 
 _characters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+window.anvilExtras = window.get("anvilExtras", {})
+window.anvilExtras["injectedHtml"] = window.anvilExtras.get("injectedHtml", {})
+_injectedHtml = window.anvilExtras["injectedHtml"]
 
 
 class HTMLInjector:
-    _injected_css = set()
+    def _is_injected(self, text, type):
+        hashed = hash((type, text))
+        if hashed in _injectedHtml:
+            return True
+        _injectedHtml[hashed] = True
+        return False
 
     def css(self, css):
         """inject some custom css"""
-        hashed = hash(css)
-        if hashed in self._injected_css:
+        if self._is_injected(css, "css"):
             return
         sheet = self._create_tag("style")
         sheet.innerHTML = css
         self._inject(sheet, head=False)
-        self._injected_css.add(hashed)
 
     def cdn(self, cdn_url, **attrs):
         """inject a js/css cdn file"""
+        if self._is_injected(cdn_url, "cdn"):
+            return
         if cdn_url.endswith("js"):
             tag = self._create_tag("script", src=cdn_url, **attrs)
         elif cdn_url.endswith("css"):
@@ -44,6 +53,8 @@ class HTMLInjector:
 
     def script(self, js):
         """inject some javascript code inside a script tag"""
+        if self._is_injected(js, "script"):
+            return
         s = self._create_tag("script")
         s.textContent = js
         self._inject(s)


### PR DESCRIPTION
this PR facilitates the possibility that the anvil designer might do some hot module reloading
we currently don't account for this in the html injector
in a scenario where all modules are reloaded, 
but the window remains the same,
injecting html in the module scope might happen multiple times

To fix that we cache injected html on `window`, rather than on the module class (which might get hot reloaded)


