### PR TITLE
Tabs resize observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
   you will now need to use `routing.alert` in place of `anvil.alert` for an alert to be dismissed on navigation
   non-dismissible alerts will block the navigation
   https://github.com/anvilistas/anvil-extras/pull/437
+* tabs - ensure the selected tab indicator adjusts when the tab component changes size
+  https://github.com/anvilistas/anvil-extras/pull/467
 
 ## Minor Changes
 * wait_for_writeback is now written in pure python

--- a/client_code/Tabs/__init__.py
+++ b/client_code/Tabs/__init__.py
@@ -179,15 +179,19 @@ class Tabs(TabsTemplate):
         )
 
     def _set_indicator(self, tab_index=None):
+        animate = tab_index is not None
         tab_index = tab_index if tab_index is not None else self._prev
 
         for i, node in enumerate(self._link_nodes):
             node.classList.toggle("active", i == tab_index)
 
         left, right = (0, 90) if tab_index <= self._prev else (90, 0)
-        self._indicator.style.transition = (
-            f"left 300ms ease-out {left}ms, right 300ms ease-out {right}ms"
-        )
+        if animate:
+            self._indicator.style.transition = (
+                f"left 300ms ease-out {left}ms, right 300ms ease-out {right}ms"
+            )
+        else:
+            self._indicator.style.transition = ""
 
         self._prev = tab_index
         link_node = self._link_nodes[tab_index]

--- a/client_code/Tabs/form_template.yaml
+++ b/client_code/Tabs/form_template.yaml
@@ -63,3 +63,4 @@ container:
       default\"></li>\n  <li class=\"indicator\"></li>\n</ul>\n<script type=\"module\"\
       >\nimport {DesignerTabs} from \"https://deno.land/x/anvil_extras@dev-2.1.1/js/designer_components/bundle.min.js\"\
       ;\nDesignerTabs.init();\n</script>\n\n\n"}
+  event_bindings: {show: _on_show, hide: _on_hide}


### PR DESCRIPTION
Essentially if the Tabs change size the indicator should also move to reflect this
At the moment the indicator stays fixed which is odd