### PR TITLE
Pivot: Don't completely fail if items is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   https://github.com/anvilistas/anvil-extras/pull/465
 
 ## Bug Fixes
+* pivot - don't fail if self.items is not set
+  https://github.com/anvilistas/anvil-extras/pull/468
 * routing was no longer dismissing alerts on navigation
   you will now need to use `routing.alert` in place of `anvil.alert` for an alert to be dismissed on navigation
   non-dismissible alerts will block the navigation

--- a/client_code/Pivot/__init__.py
+++ b/client_code/Pivot/__init__.py
@@ -79,7 +79,7 @@ class Pivot(PivotTemplate):
         options = {
             value: self.pivot_options[key] for key, value in self.option_names.items()
         }
-        _jquery(self.pivot_node).pivotUI(self.items, options)
+        _jquery(self.pivot_node).pivotUI(self.items or [], options)
 
     def form_show(self, **event_args):
         if not self.pivot_initiated:


### PR DESCRIPTION
Useful if this was instantiated in the designer and self.items was None