### PR TITLE
improve get_rgb method to account for alpha values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   https://github.com/anvilistas/anvil-extras/pull/502
 
 ## Minor Changes
+- tabs - add better support for using faded colors e.g. `tabs.active_background = "#2196F344"`
+  https://github.com/anvilistas/anvil-extras/pull/483
 - augment - use python implementation
   https://github.com/anvilistas/anvil-extras/pull/488
 

--- a/client_code/Demo/form_template.yaml
+++ b/client_code/Demo/form_template.yaml
@@ -124,6 +124,7 @@ components:
     spacing_above: none
     spacing_below: none
     italic: false
+    active_background: '#2196F344'
     background: ''
     bold: false
   name: tabs_1

--- a/client_code/Switch/__init__.py
+++ b/client_code/Switch/__init__.py
@@ -75,7 +75,7 @@ css = """
     transition: left 0.3s ease, background 0.3s ease, box-shadow 0.1s ease, transform 0.1s ease, -webkit-box-shadow 0.1s ease, -webkit-transform 0.1s ease;
 }
 .switch label .lever:before {
-    background-color: rgb(var(--color), 0.15);
+    background-color: rgb(var(--color) / 0.15);
 }
 .switch label .lever:after {
     background-color: #F1F1F1;
@@ -86,7 +86,7 @@ input[type=checkbox]:checked:not(:disabled) ~ .lever:active::before,
 input[type=checkbox]:checked:not(:disabled).tabbed:focus ~ .lever::before {
     -webkit-transform: scale(2.4);
     transform: scale(2.4);
-    background-color: rgb(var(--color), 0.15);
+    background-color: rgb(var(--color) / 0.15);
 }
 input[type=checkbox]:not(:disabled) ~ .lever:active:before,
 input[type=checkbox]:not(:disabled).tabbed:focus ~ .lever::before {

--- a/client_code/Tabs/__init__.py
+++ b/client_code/Tabs/__init__.py
@@ -66,7 +66,7 @@ _html_injector.css(
     white-space: nowrap;
 }
 .tabs .tab a:focus,.tabs .tab a:focus.active {
-    --fallback-bg: var(--color),0.2;
+    --fallback-bg: var(--color) / 0.2;
     background-color: rgb(var(--active-bg, var(--fallback-bg)));
     outline: none
 }
@@ -81,7 +81,7 @@ _html_injector.css(
     position: absolute;
     bottom: 0;
     height: 3px;
-    background-color: rgb(var(--color), 0.4);
+    background-color: rgb(var(--color) / 0.4);
     will-change: left, right;
 }
 """

--- a/client_code/utils/_component_helpers.py
+++ b/client_code/utils/_component_helpers.py
@@ -125,9 +125,13 @@ def _get_rgb(value):
     value = _get_color(value)
     if value.startswith("#"):
         value = value[1:]
-        value = ",".join(str(int(value[i : i + 2], 16)) for i in (0, 2, 4))
+        tmp = " ".join(str(int(value[i : i + 2], 16)) for i in (0, 2, 4))
+        if len(value) == 8:
+            alpha = str(int(value[6:], 16) / 256)
+            tmp += " / " + alpha
+        value = tmp
     elif value.startswith("rgb") and value.endswith(")"):
-        value = value[value.find("("), -1]
+        value = value[value.find("(") + 1 : -1]
     else:
         raise ValueError(
             f"expected a hex value, theme color or rgb value, not, {value}"

--- a/docs/guides/components/tabs.rst
+++ b/docs/guides/components/tabs.rst
@@ -14,7 +14,7 @@ Properties
 
     Which tab should be active.
 
-:active_tab_background: color
+:active_background: color
 
     the background of the active tab.
 


### PR DESCRIPTION
@telemix probably wants to fade the active_background of a tab
So it would be better to use a hex color with an alpha value e.g. `#2196F344` where 44 is the alpha part


This PR supports that
