### PR TITLE
Retry a call to the store if it fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 - Tabs - adds active_background property
   https://github.com/anvilistas/anvil-extras/issues/481
 
+## Bug Fixes
+- storage - fix a bug in ios when indexed db accessed in a webworker and closed
+  https://github.com/anvilistas/anvil-extras/discussions/484
+
 # v2.5.2 25-Oct-2023
 * storage - fix bug with deserializing
 


### PR DESCRIPTION
This fixes a bug in IOS where a web worker is sleeping during an indexed db transaction
and then waking up and the transaction falls over
retrying the transaction fixes the bug

I wrote a PR direct to local forage library to fix this
They already do retries but don't retry on this particularly error type
If that gets merged we can probably remove this code and just update our version of local forage

@rhurlbatt  this is the fix for #484 


