### PR TITLE
Add 'usermap' option to authorisation module to avoid linked column in Users table

### DIFF
--- a/client_code/Autocomplete/form_template.yaml
+++ b/client_code/Autocomplete/form_template.yaml
@@ -17,8 +17,10 @@ properties:
   binding_writeback_events: [suggestion_clicked]
   group: text
   important: true
-- {name: enabled, type: boolean, default_value: true, group: interaction, important: true, designer_hint: enabled}
-- {name: visible, type: boolean, default_value: true, group: appearance, important: true, designer_hint: visible}
+- {name: enabled, type: boolean, default_value: true, group: interaction, important: true,
+  designer_hint: enabled}
+- {name: visible, type: boolean, default_value: true, group: appearance, important: true,
+  designer_hint: visible}
 - name: spacing_above
   type: enum
   options: [none, small, medium, large]

--- a/client_code/Chip/form_template.yaml
+++ b/client_code/Chip/form_template.yaml
@@ -16,7 +16,8 @@ properties:
   default_value: small
   group: layout
   important: false
-- {name: visible, type: boolean, default_value: true, group: appearance, important: false, designer_hint: visible}
+- {name: visible, type: boolean, default_value: true, group: appearance, important: false,
+  designer_hint: visible}
 - {name: tag, type: object, group: user data, important: false}
 is_package: true
 events:

--- a/client_code/ChipsInput/form_template.yaml
+++ b/client_code/ChipsInput/form_template.yaml
@@ -18,7 +18,8 @@ properties:
   default_value: small
   group: layout
   important: false
-- {name: visible, type: boolean, default_value: true, group: appearance, important: true, designer_hint: visible}
+- {name: visible, type: boolean, default_value: true, group: appearance, important: true,
+  designer_hint: visible}
 - {name: tag, type: object, group: user data, important: false}
 - {name: primary_placeholder, type: string, default_value: Enter a Tag, description: placeholder when there are no chips}
 - {name: secondary_placeholder, type: string, default_value: +Tag, description: placeholder when there are chips}

--- a/client_code/MultiSelectDropDown/form_template.yaml
+++ b/client_code/MultiSelectDropDown/form_template.yaml
@@ -12,10 +12,12 @@ properties:
 - {name: enable_filtering, type: boolean, default_value: null, group: interaction,
   important: false}
 - {name: multiple, type: boolean, default_value: true, group: interaction, important: false}
-- {name: enabled, type: boolean, default_value: true, group: interaction, important: true, designer_hint: enabled}
+- {name: enabled, type: boolean, default_value: true, group: interaction, important: true,
+  designer_hint: enabled}
 - {name: enable_select_all, type: boolean, default_value: false, group: interaction,
   important: false}
-- {name: visible, type: boolean, default_value: true, group: appearance, important: true, designer_hint: visible}
+- {name: visible, type: boolean, default_value: true, group: appearance, important: true,
+  designer_hint: visible}
 - {name: width, type: string, default_value: '', group: appearance, description: use css lengths. \'auto\' sets the width as wide as the largest option,
   \'fit\' resizes to the selected content: null}
 - name: spacing_above

--- a/client_code/Slider/form_template.yaml
+++ b/client_code/Slider/form_template.yaml
@@ -31,9 +31,11 @@ properties:
     a "-" separated list of "drag", "tap", "fixed", "snap", "unconstrained" or "none"',
   group: interaction, important: false}
 - {name: color, type: color, default_value: null, group: appearance, important: false}
-- {name: visible, type: boolean, default_value: true, group: appearance, important: true, designer_hint: visible}
+- {name: visible, type: boolean, default_value: true, group: appearance, important: true,
+  designer_hint: visible}
 - {name: tag, type: object, group: user data, important: false}
-- {name: enabled, type: boolean, default_value: true, group: interaction, important: true, designer_hint: enabled}
+- {name: enabled, type: boolean, default_value: true, group: interaction, important: true,
+  designer_hint: enabled}
 - name: spacing_above
   type: enum
   options: [none, small, medium, large]

--- a/client_code/Tabs/form_template.yaml
+++ b/client_code/Tabs/form_template.yaml
@@ -20,7 +20,8 @@ properties:
   group: text
   important: false
   designer_hint: align-horizontal
-- {name: visible, type: boolean, default_value: true, group: appearance, important: true, designer_hint: visible}
+- {name: visible, type: boolean, default_value: true, group: appearance, important: true,
+  designer_hint: visible}
 - {name: tag, type: object, group: user data, important: false}
 - name: spacing_above
   type: enum
@@ -34,9 +35,11 @@ properties:
   default_value: none
   group: layout
   important: false
-- {name: bold, type: boolean, default_value: null, group: text, important: false, designer_hint: font-bold}
+- {name: bold, type: boolean, default_value: null, group: text, important: false,
+  designer_hint: font-bold}
 - {name: font_size, type: string, default_value: null, group: text, important: false}
-- {name: italic, type: boolean, default_value: null, group: text, important: false, designer_hint: font-italic}
+- {name: italic, type: boolean, default_value: null, group: text, important: false,
+  designer_hint: font-italic}
 - {name: font, type: string, default_value: '', group: text, important: false}
 is_package: true
 events:

--- a/docs/guides/modules/authorisation.rst
+++ b/docs/guides/modules/authorisation.rst
@@ -9,10 +9,18 @@ Installation
 You will need to setup the Users and Data Table services in your app:
 
   * Ensure that you have added the 'Users' service to your app
+
+Classic Mode (requires changes to Users table):
   * In the 'Data Tables' service, add:
   	* a table named 'permissions' with a text column named 'name'
 	* a table named 'roles' with a text column named 'name' and a 'link to table'column named 'permissions' that links to multiple rows of the permissions table
 	* a new 'link to table' column in the Users table named 'roles' that links to multiple rows of the 'roles' table
+
+Usermap Mode (no changes to Users table):
+  * In the 'Data Tables' service, add:
+  	* a table named 'permissions' with a text column named 'name'
+	* a table named 'roles' with a text column named 'name' and a 'link to table'column named 'permissions' that links to multiple rows of the permissions table
+	* a table named 'usermap' with a 'link to table' column named 'user' that links to a single row of the 'users' table and a 'link to table' column named 'roles' that links to multiple rows of the 'roles' table
 
 Usage
 -----
@@ -22,7 +30,8 @@ Users and Permissions
 
 * Add entries to the permissions table. (e.g. 'can_view_stuff', 'can_edit_sensitive_thing')
 * Add entries to the roles table (e.g. 'admin') with links to the relevant permissions
-* In the Users table, link users to the relevant roles
+* Classic mode: In the Users table, link users to the relevant roles
+* Usermap mode: In the usermap table, link users to the relevant roles
 
 Server Functions
 ++++++++++++++++
@@ -52,6 +61,10 @@ function is called and raises an error if not:
 
     import anvil.server
     from anvil_extras.authorisation import authorisation_required
+    from anvil_extras import authorisation
+
+    # optional - default mode is "classic"
+    authorisation.set_mode("classic")
 
     @anvil.server.callable
     @authorisation_required("can_edit_sensitive_thing")

--- a/server_code/authorisation.py
+++ b/server_code/authorisation.py
@@ -7,8 +7,24 @@
 import functools
 
 import anvil.users
+from anvil.tables import app_tables
 
 __version__ = "2.6.0"
+
+_default_mode = "classic"
+
+
+def _validate_mode(mode):
+    if mode not in ("classic", "usermap"):
+        raise ValueError(
+            "The authorisation mode can only be 'classic' or 'usermap'"
+        )
+
+
+def set_mode(mode):
+    global _default_mode
+    _validate_mode(mode)
+    _default_mode = mode
 
 
 def authentication_required(func):
@@ -35,6 +51,16 @@ def has_permission(permissions):
     else:
         required_permissions = set(permissions)
 
+    if _default_mode == 'classic':
+        user_permissions = has_permission_classic(user)
+    else:
+        user_permissions = has_permission_usermap(user)
+
+    return required_permissions.issubset(user_permissions)
+
+
+def has_permission_classic(user):
+    """Returns user_permissions set for classic mode."""
     try:
         user_permissions = set(
             permission["name"]
@@ -43,9 +69,21 @@ def has_permission(permissions):
         )
     except TypeError:
         return False
+    return user_permissions
 
-    return required_permissions.issubset(user_permissions)
 
+def has_permission_usermap(user):
+    """Returns user_permissions set for usermap mode."""
+    usermap = app_tables.usermap.get(user=user)
+    try:
+        user_permissions = set(
+            permission["name"]
+            for role in usermap["roles"]
+            for permission in role["permissions"]
+        )
+    except TypeError:
+        return False
+    return user_permissions
 
 def check_permissions(permissions):
     """Checks a users permissions, raises ValueError if user does not have permissions"""


### PR DESCRIPTION
As per #515 

Works like this:



    import anvil.server
    from anvil_extras.authorisation import authorisation_required
    from anvil_extras import authorisation

    # optional - default mode is "classic". Now supports "usermap"
    authorisation.set_mode("classic")

    @anvil.server.callable
    @authorisation_required("can_edit_sensitive_thing")
    def sensitive_server_function():
      do_stuff()