### PR TITLE
Fix lever color in switch component

### DIFF
--- a/client_code/Autocomplete/form_template.yaml
+++ b/client_code/Autocomplete/form_template.yaml
@@ -17,8 +17,10 @@ properties:
   binding_writeback_events: [suggestion_clicked]
   group: text
   important: true
-- {name: enabled, type: boolean, default_value: true, group: interaction, important: true, designer_hint: enabled}
-- {name: visible, type: boolean, default_value: true, group: appearance, important: true, designer_hint: visible}
+- {name: enabled, type: boolean, default_value: true, group: interaction, important: true,
+  designer_hint: enabled}
+- {name: visible, type: boolean, default_value: true, group: appearance, important: true,
+  designer_hint: visible}
 - name: spacing_above
   type: enum
   options: [none, small, medium, large]

--- a/client_code/Chip/form_template.yaml
+++ b/client_code/Chip/form_template.yaml
@@ -16,7 +16,8 @@ properties:
   default_value: small
   group: layout
   important: false
-- {name: visible, type: boolean, default_value: true, group: appearance, important: false, designer_hint: visible}
+- {name: visible, type: boolean, default_value: true, group: appearance, important: false,
+  designer_hint: visible}
 - {name: tag, type: object, group: user data, important: false}
 is_package: true
 events:

--- a/client_code/ChipsInput/form_template.yaml
+++ b/client_code/ChipsInput/form_template.yaml
@@ -18,7 +18,8 @@ properties:
   default_value: small
   group: layout
   important: false
-- {name: visible, type: boolean, default_value: true, group: appearance, important: true, designer_hint: visible}
+- {name: visible, type: boolean, default_value: true, group: appearance, important: true,
+  designer_hint: visible}
 - {name: tag, type: object, group: user data, important: false}
 - {name: primary_placeholder, type: string, default_value: Enter a Tag, description: placeholder when there are no chips}
 - {name: secondary_placeholder, type: string, default_value: +Tag, description: placeholder when there are chips}

--- a/client_code/MultiSelectDropDown/form_template.yaml
+++ b/client_code/MultiSelectDropDown/form_template.yaml
@@ -12,10 +12,12 @@ properties:
 - {name: enable_filtering, type: boolean, default_value: null, group: interaction,
   important: false}
 - {name: multiple, type: boolean, default_value: true, group: interaction, important: false}
-- {name: enabled, type: boolean, default_value: true, group: interaction, important: true, designer_hint: enabled}
+- {name: enabled, type: boolean, default_value: true, group: interaction, important: true,
+  designer_hint: enabled}
 - {name: enable_select_all, type: boolean, default_value: false, group: interaction,
   important: false}
-- {name: visible, type: boolean, default_value: true, group: appearance, important: true, designer_hint: visible}
+- {name: visible, type: boolean, default_value: true, group: appearance, important: true,
+  designer_hint: visible}
 - {name: width, type: string, default_value: '', group: appearance, description: use css lengths. \'auto\' sets the width as wide as the largest option,
   \'fit\' resizes to the selected content: null}
 - name: spacing_above

--- a/client_code/Slider/form_template.yaml
+++ b/client_code/Slider/form_template.yaml
@@ -31,9 +31,11 @@ properties:
     a "-" separated list of "drag", "tap", "fixed", "snap", "unconstrained" or "none"',
   group: interaction, important: false}
 - {name: color, type: color, default_value: null, group: appearance, important: false}
-- {name: visible, type: boolean, default_value: true, group: appearance, important: true, designer_hint: visible}
+- {name: visible, type: boolean, default_value: true, group: appearance, important: true,
+  designer_hint: visible}
 - {name: tag, type: object, group: user data, important: false}
-- {name: enabled, type: boolean, default_value: true, group: interaction, important: true, designer_hint: enabled}
+- {name: enabled, type: boolean, default_value: true, group: interaction, important: true,
+  designer_hint: enabled}
 - name: spacing_above
   type: enum
   options: [none, small, medium, large]

--- a/client_code/Switch/__init__.py
+++ b/client_code/Switch/__init__.py
@@ -35,7 +35,7 @@ css = """
     height: 0;
 }
 .switch label input[type=checkbox]:checked+.lever {
-    background-color: rgba(var(--color), .5);
+    background-color: rgba(var(--color) / .5);
 }
 .switch label input[type=checkbox]:checked+.lever:after,
 .switch label input[type=checkbox]:checked+.lever:before {

--- a/client_code/Tabs/form_template.yaml
+++ b/client_code/Tabs/form_template.yaml
@@ -20,7 +20,8 @@ properties:
   group: text
   important: false
   designer_hint: align-horizontal
-- {name: visible, type: boolean, default_value: true, group: appearance, important: true, designer_hint: visible}
+- {name: visible, type: boolean, default_value: true, group: appearance, important: true,
+  designer_hint: visible}
 - {name: tag, type: object, group: user data, important: false}
 - name: spacing_above
   type: enum
@@ -34,9 +35,11 @@ properties:
   default_value: none
   group: layout
   important: false
-- {name: bold, type: boolean, default_value: null, group: text, important: false, designer_hint: font-bold}
+- {name: bold, type: boolean, default_value: null, group: text, important: false,
+  designer_hint: font-bold}
 - {name: font_size, type: string, default_value: null, group: text, important: false}
-- {name: italic, type: boolean, default_value: null, group: text, important: false, designer_hint: font-italic}
+- {name: italic, type: boolean, default_value: null, group: text, important: false,
+  designer_hint: font-italic}
 - {name: font, type: string, default_value: '', group: text, important: false}
 is_package: true
 events:


### PR DESCRIPTION
The switch component wasn't incorporating the transparency correctly. As a result, the bar behind the switch was turning white when checked.

I just changed one line:

    background-color: rgba(var(--color), .5);

To:

    background-color: rgba(var(--color) / .5);
    
    
All the other changes (to the yaml files) were done by the Anvil Editor.