### PR TITLE
🐛️Expand the kwargs passed by persistence get method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Bug Fixes
+* persistence - fix get method
+  https://github.com/anvilistas/anvil-extras/issues/523
+
 # v2.6.1 27-Mar-2024
 
 ## Bug Fixes

--- a/client_code/persistence.py
+++ b/client_code/persistence.py
@@ -113,7 +113,7 @@ class PersistedClass:
         try:
             return cls._cache[key]
         except KeyError:
-            row = anvil.server.call(f"get_{cls._snake_name}", {cls.key: key})
+            row = anvil.server.call(f"get_{cls._snake_name}", **{cls.key: key})
             obj = cls(store=row)
             cls._cache[key] = obj
             return obj


### PR DESCRIPTION
Because:
- The server side function expects a kwarg, not a dict

Fixes #523