### PR TITLE
Add Proxy class to those passed through to storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Enhancements
 * authorisation - added config option to avoid adding a roles column to the users table
   https://github.com/anvilistas/anvil-extras/pull/516
+* storage - proxyobjects are passed to the underlying storage so that those implementing the serializable interface can be stored
 
 ## Bug Fixes
 * persistence - fix get method

--- a/client_code/storage.py
+++ b/client_code/storage.py
@@ -43,7 +43,7 @@ def _is_str(key):
 def _serialize(obj):
     # we won't support subclasses of builtins so just check type is
     ob_type = type(obj)
-    if ob_type in (str, int, float, bool, _NoneType, bytes):
+    if ob_type in (str, int, float, bool, _NoneType, bytes, _Proxy):
         return obj
     elif ob_type in (list, tuple, _Array):
         return [_serialize(item) for item in obj]


### PR DESCRIPTION
Several js objects implement the serializable interface (based on the structured clone algorithm):
https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types

and that is used by indexed db.

This PR adds the Proxy class to the list of types that the storage module passes through.