### PR TITLE
Add reset to persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Minor Changes
+* persistence - add reset method
+
 ## Bug Fixes
 * multiselect - fix bug where enable_selct_all was not being set correctly
   https://anvil.works/forum/t/anvil-extras-2-6/21252/4

--- a/client_code/persistence.py
+++ b/client_code/persistence.py
@@ -169,6 +169,9 @@ class PersistedClass:
         anvil.server.call(f"delete_{self._snake_name}", self._store, *args, **kwargs)
         self._delta.clear()
 
+    def reset(self):
+        self._delta.clear()
+
 
 def persisted_class(cls):
     """A decorator for a class with a persistence mechanism"""


### PR DESCRIPTION
If you're in a form that lets you make changes to a persistence object and then you "cancel", the changes are still in the delta. This reset method allows the the delta to be cleared.