### PR TITLE
non-blocking: fix catching exceptions when directly accessing non-blocking promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Bug Fixes
 * multiselect - fix bug where enable_selct_all was not being set correctly
   https://anvil.works/forum/t/anvil-extras-2-6/21252/4
+* non-blocking - fix catching exceptions when accessing a non-blocking promise
+  https://github.com/anvilistas/anvil-extras/pull/543
 
 # v2.6.2 13-Jun-2024
 

--- a/client_code/non_blocking.py
+++ b/client_code/non_blocking.py
@@ -116,7 +116,7 @@ class _AsyncCall:
         """Returns: JavaScript Promise that resolves to the value from the function call"""
         return _W.Promise(
             lambda resolve, reject: resolve(
-                self._deferred.promise.then(lambda r: r.value)
+                self._deferred.promise.then(lambda r: r.value, reject)
             )
         )
 


### PR DESCRIPTION
Without this if the promise rejects we aren't able to catch it correctly

