### PR TITLE
Persistence data descriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Minor Changes
 * persistence - add reset method
   https://github.com/anvilistas/anvil-extras/pull/542
+* persistence - add set behaviour for linked classes
 ## Bug Fixes
 * multiselect - fix bug where enable_selct_all was not being set correctly
   https://anvil.works/forum/t/anvil-extras-2-6/21252/4

--- a/client_code/persistence.py
+++ b/client_code/persistence.py
@@ -77,9 +77,7 @@ class LinkedClass:
         )
 
     def __set__(self, instance, value):
-        raise AttributeError(
-            "Linked Class instance is already set and cannot be changed"
-        )
+        instance._delta[self._linked_column] = value._store
 
 
 class PersistedClass:

--- a/client_code/persistence.py
+++ b/client_code/persistence.py
@@ -72,12 +72,23 @@ class LinkedClass:
         if instance is None:
             return self
 
+        if instance._delta and self._linked_column in instance._delta:
+            return self._cls(
+                instance._delta[self._linked_column], *self._args, **self._kwargs
+            )
         return self._cls(
             instance._store[self._linked_column], *self._args, **self._kwargs
         )
 
+        store = (
+            instance._delta
+            if instance._delta and self._linked_column in instance._delta
+            else instance._store
+        )
+        return self._cls(store[self._linked_column], *self._args, **self._kwargs)
+
     def __set__(self, instance, value):
-        instance._delta[self._linked_column] = value._store
+        instance._delta[self._linked_column] = self._cls(value._store)
 
 
 class PersistedClass:

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -64,6 +64,15 @@ def linked_persisted_book(book_store):
     return Book(book_store)
 
 
+@pytest.fixture
+def douglas_adams():
+    @ps.persisted_class
+    class Author:
+        pass
+
+    return Author({"name": "Douglas Adams"})
+
+
 def test_linked_attribute(book, book_store):
     """Test that the LinkedAttribute class works independently of persisted_class"""
     assert book.author_name == "Luciano Ramalho"
@@ -130,12 +139,10 @@ def test_linked_class(linked_persisted_book):
     assert linked_persisted_book.author.name == "Luciano Ramalho"
 
 
-def test_linked_class_set(linked_persisted_book):
-    """Test that attempting to change a linked class instance raises an error"""
-    with pytest.raises(AttributeError) as excinfo:
-        linked_persisted_book.author = "test"
-
-    assert "Linked Class instance is already set" in str(excinfo.value)
+def test_linked_class_set(linked_persisted_book, douglas_adams):
+    """Test that changing a linked class instance behaves as expected"""
+    linked_persisted_book.author = douglas_adams
+    assert linked_persisted_book.author.name == "Douglas Adams"
 
 
 def test_non_attributes_in_local_store(persisted_book):


### PR DESCRIPTION
The persistence module expressly prohibited changing linked class instances. It instead raised an error in the linked class descriptor. 
This PR replaces that behaviour by recording the change in the parent object's _delta.