### PR TITLE
Fix augment name conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
   https://github.com/anvilistas/anvil-extras/issues/545
 * mulitselect - fix bug where properties were not being set correctly
   https://github.com/anvilistas/anvil-extras/issues/554
+* augment - fix bug where event couldn't be used as a raise_event kw
+  https://anvil.works/forum/t/tabulator-multiple-value-error-on-row-click/22158/9
 
 ## New Features
 * quill - implement get_markdown()

--- a/client_code/augment.py
+++ b/client_code/augment.py
@@ -165,15 +165,15 @@ def wrap_event_method(method):
     old_method = getattr(_Component, method)
 
     @_wraps(old_method)
-    def wrapped(self, event, *args, **kws):
-        key = (type(self), event)
+    def wrapped(self, event_name, *args, **kws):
+        key = (type(self), event_name)
         if key not in _remap:
-            return old_method(self, event, *args, **kws)
+            return old_method(self, event_name, *args, **kws)
 
-        remapped = _prefix + event
+        remapped = _prefix + event_name
 
         if len(args) == 1 and callable(args[0]):
-            args = [_get_handler(args[0], event)]
+            args = [_get_handler(args[0], event_name)]
 
         return old_method(self, remapped, *args, **kws)
 


### PR DESCRIPTION
This monkey patch breaks code that does

```
self.raise_event("foo", event=some_event)
```

`event_name` should be a safe name here

you shouldn't do `raise_event("foo", event_name="bar")` because event_name gets overridden to `"foo"` anyway.

