### PR TITLE
Add better rgb support

### DIFF
--- a/client_code/Tabs/__init__.py
+++ b/client_code/Tabs/__init__.py
@@ -51,7 +51,7 @@ _html_injector.css(
     text-transform: uppercase
 }
 .ae-tabs .ae-tab a {
-    color: rgba(var(--color),0.7);
+    color: rgb(var(--color) / 0.7);
     display: block;
     width: 100%;
     height: 100%;

--- a/client_code/utils/_component_helpers.py
+++ b/client_code/utils/_component_helpers.py
@@ -121,21 +121,64 @@ def _get_color(value):
         return value
 
 
+_hidden_style_getter = None
+
+
+def _get_computed_color(value):
+    global _hidden_style_getter
+    if _hidden_style_getter is None:
+        container = _document.createElement("div")
+        container.style.display = "none"
+        container.style.color = "chartreuse"  # obscure color
+        _hidden_style_getter = _document.createElement("style")
+        container.appendChild(_hidden_style_getter)
+        _document.body.appendChild(container)
+
+    _hidden_style_getter.style.color = ""
+    _hidden_style_getter.style.color = value
+
+    computed = window.getComputedStyle(_hidden_style_getter).color
+    if computed == "rgb(127, 255, 0)":
+        return value
+    else:
+        return computed
+
+
+def _strip_rgba(value):
+    original = value
+
+    value = value.strip()
+
+    if value.startswith("rgba("):
+        value = value[5:]
+
+    if value.startswith("rgb("):
+        value = value[4:]
+
+    if value.endswith(")"):
+        value = value[:-1]
+
+    value = value.split(", ")
+
+    if len(value) == 3:
+        return " ".join(value)
+
+    if len(value) == 4:
+        return f"{value[0]} {value[1]} {value[2]} / {value[3]}"
+
+    return original
+
+
 def _get_rgb(value):
     value = _get_color(value)
-    if value.startswith("#"):
-        value = value[1:]
-        tmp = " ".join(str(int(value[i : i + 2], 16)) for i in (0, 2, 4))
-        if len(value) == 8:
-            alpha = str(int(value[6:], 16) / 256)
-            tmp += " / " + alpha
-        value = tmp
-    elif value.startswith("rgb") and value.endswith(")"):
-        value = value[value.find("(") + 1 : -1]
+
+    if value.startswith("--"):
+        # css var
+        pass
     else:
-        raise ValueError(
-            f"expected a hex value, theme color or rgb value, not, {value}"
-        )
+        value = _get_computed_color(value)
+        value = _strip_rgba(value)
+
     return value
 
 


### PR DESCRIPTION
Current failings with `_get_rgb`:
- we don't support css vars
- we don't support known colors e.g. `red`
- we have a couple of bugs with misuse of commas in `rgb` css

Approach in this PR:
- add a hidden dom element to page body
- This hidden dom element is wrapped in a hidden container with an obscure color
- set the style of the hidden element
- use window.getComputedStyle which returns `rgb(r, g, b)` or `rgba(r, g, b, a)`
- convert this color to the required space separated values that can then be added to our css vars


Also fixes the tab color is not being applied correctly to the inactive tabs

close #568 