### PR TITLE
relative colors

### DIFF
--- a/client_code/Switch/__init__.py
+++ b/client_code/Switch/__init__.py
@@ -5,15 +5,24 @@
 #
 # This software is published at https://github.com/anvilistas/anvil-extras
 
-from anvil import CheckBox, app
+from anvil import CheckBox
 from anvil.js import get_dom_node as _get_dom_node
 from anvil.js.window import document as _document
 
-from ..utils._component_helpers import _get_rgb, _html_injector
+from ..utils._component_helpers import (
+    _get_color,
+    _get_rgb,
+    _html_injector,
+    _primary_color,
+    _supports_relative_colors,
+)
 
 __version__ = "3.0.0"
 
-primary = app.theme_colors.get("Primary 500", "#2196F3")
+primary = _primary_color
+
+if _supports_relative_colors():
+    _get_rgb = _get_color
 
 css = """
 .ae-switch,
@@ -100,6 +109,15 @@ input[type=checkbox]:not(:disabled) ~ .ae-switch-lever:active:before {
 .ae-switch label input[type=checkbox][disabled]+.ae-switch-lever:after,
 .ae-switch label input[type=checkbox][disabled]:checked+.ae-switch-lever:after {
     background-color: #949494;
+}
+
+@supports (color: rgb(from white r g b / 0.2)) {
+    .ae-switch label input[type=checkbox]:checked+.ae-switch-lever {
+        background-color: rgba(from var(--color) r g b / .5);
+    }
+    .ae-switch label input[type=checkbox]:checked+.ae-switch-lever:after {
+        background-color: var(--color);
+    }
 }
 
 """

--- a/client_code/Tabs/__init__.py
+++ b/client_code/Tabs/__init__.py
@@ -16,6 +16,7 @@ from ..utils._component_helpers import (
     _get_rgb,
     _html_injector,
     _spacing_property,
+    _supports_relative_colors,
 )
 from ._anvil_designer import TabsTemplate
 
@@ -84,8 +85,30 @@ _html_injector.css(
     background-color: rgb(var(--color) / 0.4);
     will-change: left, right;
 }
+
+@supports (color: rgb(from white r g b / 0.2)) {
+    .ae-tabs .ae-tab a:hover,.ae-tabs .ae-tab a.ae-tab-active {
+        color: var(--color);
+    }
+    .ae-tabs .ae-tab a {
+        color: rgb(from var(--color) r g b / 0.7);
+    }
+    .ae-tabs .ae-tab a:focus,.ae-tabs .ae-tab a:focus.ae-tab-active {
+        --fallback-bg: rgb(from var(--color) r g b / 0.2);
+        background-color: var(--active-bg, var(--fallback-bg));
+    }
+    .ae-tabs .ae-tab a:hover,.ae-tabs .ae-tab a.ae-tab-active {
+        background-color: var(--active-bg);
+    }
+    .ae-tabs .ae-tab-indicator {
+        background-color: rgb(from var(--color) r g b / 0.4);
+    }
+}
 """
 )
+
+if _supports_relative_colors():
+    _get_rgb = _get_color
 
 _defaults = {
     "align": "left",

--- a/client_code/utils/_component_helpers.py
+++ b/client_code/utils/_component_helpers.py
@@ -112,6 +112,10 @@ _primary_color = (window.document.querySelector("meta[name=theme-color]") or {})
 )
 
 
+def _supports_relative_colors():
+    return window.CSS.supports("color", "rgb(from white r g b / 0.2)")
+
+
 def _get_color(value):
     if not value:
         return _primary_color


### PR DESCRIPTION
improves colors for tabs and switches

allows arbirtrary colors to be used including css vars
uses modern browser rgb(from color r g b / a) syntax
fallsback to previous implementation if that is not supported

addresses #568
