### PR TITLE
Added support for Logger usage in messaging.py

### DIFF
--- a/client_code/messaging.py
+++ b/client_code/messaging.py
@@ -6,6 +6,7 @@
 # This software is published at https://github.com/anvilistas/anvil-extras
 
 from logging import Logger
+
 __version__ = "3.0.0"
 
 
@@ -41,7 +42,7 @@ class Publisher:
                 with_logging.log(
                     log_level,
                     f"Published '{message.title}' message on '{channel}' channel to "
-                    f"{len(subscribers)} subscriber(s)"
+                    f"{len(subscribers)} subscriber(s)",
                 )
             else:
                 print(
@@ -49,7 +50,9 @@ class Publisher:
                     f"{len(subscribers)} subscriber(s)"
                 )
 
-    def subscribe(self, channel, subscriber, handler, with_logging=None, log_level=None):
+    def subscribe(
+        self, channel, subscriber, handler, with_logging=None, log_level=None
+    ):
         if with_logging is None:
             with_logging = self.with_logging
         if log_level is None:
@@ -74,7 +77,9 @@ class Publisher:
             ]
         if with_logging:
             if isinstance(with_logging, Logger):
-                with_logging.log(log_level, f"Removed subscriber from {channel} channel")
+                with_logging.log(
+                    log_level, f"Removed subscriber from {channel} channel"
+                )
             else:
                 print(f"Removed subscriber from {channel} channel")
 
@@ -87,6 +92,8 @@ class Publisher:
         del self.subscribers[channel]
         if with_logging:
             if isinstance(with_logging, Logger):
-                with_logging.log(log_level, f"{channel} closed ({subscribers_count} subscribers)")
+                with_logging.log(
+                    log_level, f"{channel} closed ({subscribers_count} subscribers)"
+                )
             else:
                 print(f"{channel} closed ({subscribers_count} subscribers)")

--- a/client_code/messaging.py
+++ b/client_code/messaging.py
@@ -4,6 +4,8 @@
 # https://github.com/anvilistas/anvil-extras/graphs/contributors
 #
 # This software is published at https://github.com/anvilistas/anvil-extras
+
+from logging import Logger
 __version__ = "3.0.0"
 
 
@@ -20,46 +22,71 @@ class Subscriber:
 
 
 class Publisher:
-    def __init__(self, with_logging=True):
+    def __init__(self, with_logging=True, log_level="INFO"):
         self.with_logging = with_logging
         self.subscribers = {}
+        self.log_level = log_level
 
-    def publish(self, channel, title, content=None, with_logging=None):
+    def publish(self, channel, title, content=None, with_logging=None, log_level=None):
         if with_logging is None:
             with_logging = self.with_logging
+        if log_level is None:
+            log_level = self.log_level
         message = Message(title, content)
         subscribers = self.subscribers.get(channel, [])
         for subscriber in subscribers:
             subscriber.handler(message)
         if with_logging:
-            print(
-                f"Published '{message.title}' message on '{channel}' channel to "
-                f"{len(subscribers)} subscriber(s)"
-            )
+            if isinstance(with_logging, Logger):
+                with_logging.log(
+                    log_level,
+                    f"Published '{message.title}' message on '{channel}' channel to "
+                    f"{len(subscribers)} subscriber(s)"
+                )
+            else:
+                print(
+                    f"Published '{message.title}' message on '{channel}' channel to "
+                    f"{len(subscribers)} subscriber(s)"
+                )
 
-    def subscribe(self, channel, subscriber, handler, with_logging=None):
+    def subscribe(self, channel, subscriber, handler, with_logging=None, log_level=None):
         if with_logging is None:
             with_logging = self.with_logging
+        if log_level is None:
+            log_level = self.log_level
         if channel not in self.subscribers:
             self.subscribers[channel] = []
         self.subscribers[channel].append(Subscriber(subscriber, handler))
         if with_logging:
-            print(f"Added subscriber to {channel} channel")
+            if isinstance(with_logging, Logger):
+                with_logging.log(log_level, f"Added subscriber to {channel} channel")
+            else:
+                print(f"Added subscriber to {channel} channel")
 
-    def unsubscribe(self, channel, subscriber, with_logging=None):
+    def unsubscribe(self, channel, subscriber, with_logging=None, log_level=None):
         if with_logging is None:
             with_logging = self.with_logging
+        if log_level is None:
+            log_level = self.log_level
         if channel in self.subscribers:
             self.subscribers[channel] = [
                 s for s in self.subscribers[channel] if s.subscriber != subscriber
             ]
         if with_logging:
-            print(f"Removed subscriber from {channel} channel")
+            if isinstance(with_logging, Logger):
+                with_logging.log(log_level, f"Removed subscriber from {channel} channel")
+            else:
+                print(f"Removed subscriber from {channel} channel")
 
-    def close_channel(self, channel, with_logging=None):
+    def close_channel(self, channel, with_logging=None, log_level=None):
         if with_logging is None:
             with_logging = self.with_logging
+        if log_level is None:
+            log_level = self.log_level
         subscribers_count = len(self.subscribers[channel])
         del self.subscribers[channel]
         if with_logging:
-            print(f"{channel} closed ({subscribers_count} subscribers)")
+            if isinstance(with_logging, Logger):
+                with_logging.log(log_level, f"{channel} closed ({subscribers_count} subscribers)")
+            else:
+                print(f"{channel} closed ({subscribers_count} subscribers)")

--- a/docs/guides/modules/messaging.rst
+++ b/docs/guides/modules/messaging.rst
@@ -90,12 +90,10 @@ continue to be called.
 
 Logging
 +++++++
-By default, the publisher will log each message it receieves to your app's logs (and
+The publisher can log each message it receieves to your app's logs (and
 the output pane if you're in the IDE) using a `Logger` instance.
 
-You can change this default behaviour when you first create your publisher instance:
-
-
+You can do this by passing a `Logger` instance when you first create a Publisher:
 
 .. code-block:: python
 
@@ -106,5 +104,19 @@ You can change this default behaviour when you first create your publisher insta
     )
 
 The `publish`, `subscribe`, `unsubscribe` and `close_channel` methods will each use the
-`logger` informed at creation (or a default of not informed) and log the message at INFO level.
+`logger` informed at creation.
+
+By default, if no logger is informed, no messages will be logged. Also, messages will be logged at INFO level by default.
+To change this behavior globally you can do the following:
+
+.. code-block:: python
+
+    from anvil_extras.messaging import Publisher
+    from anvil_extras.logging import Logger, ERROR
+
+    # The following line sets the default logger to be used for every new published instance created after it's set
+    Publisher.default_logger = Logger(name="publisher", level=INFO, format="{datetime:%Y-%m-%d %H:%M:%S}: {msg}")
+    # The following line sets the overrides the default log level (INFO) to ERROR for all publishers that have a logger.
+    Publisher.default_log_level = ERROR
+
 For more information, check the Logging page in the docs.

--- a/docs/guides/modules/messaging.rst
+++ b/docs/guides/modules/messaging.rst
@@ -91,7 +91,7 @@ continue to be called.
 Logging
 +++++++
 By default, the publisher will log each message it receieves to your app's logs (and
-the output pane if you're in the IDE).
+the output pane if you're in the IDE) using a `Logger` instance.
 
 You can change this default behaviour when you first create your publisher instance:
 
@@ -100,8 +100,11 @@ You can change this default behaviour when you first create your publisher insta
 .. code-block:: python
 
     from anvil_extras.messaging import Publisher
-    publisher = Publisher(with_logging=False)
+    from anvil_extras.logging import Logger, INFO
+    publisher = Publisher(
+        logger=Logger(name="publisher", level=INFO, format="{datetime:%Y-%m-%d %H:%M:%S}: {msg}")
     )
 
-The `publish`, `subscribe`, `unsubscribe` and `close_channel` methods each take an
-optional `with_logging` parameter which can be used to override the default behaviour.
+The `publish`, `subscribe`, `unsubscribe` and `close_channel` methods will each use the
+`logger` informed at creation (or a default of not informed) and log the message at INFO level.
+For more information, check the Logging page in the docs.

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -2,7 +2,8 @@ from client_code import messaging
 
 
 def test_default_logging(capsys):
-    publisher = messaging.Publisher()
+    from client_code.logging import Logger, DEBUG
+    publisher = messaging.Publisher(logger=Logger(level=DEBUG))
     publisher.publish("test_channel", "test_message")
     captured = capsys.readouterr()
     assert (
@@ -12,24 +13,7 @@ def test_default_logging(capsys):
 
 
 def test_no_logging_default(capsys):
-    publisher = messaging.Publisher(with_logging=False)
+    publisher = messaging.Publisher()
     publisher.publish("test_channel", "test_message")
     captured = capsys.readouterr()
     assert captured.out == ""
-
-
-def test_default_logging_override(capsys):
-    publisher = messaging.Publisher()
-    publisher.publish("test_channel", "test_message", with_logging=False)
-    captured = capsys.readouterr()
-    assert captured.out == ""
-
-
-def test_no_logging_override(capsys):
-    publisher = messaging.Publisher(with_logging=False)
-    publisher.publish("test_channel", "test_message", with_logging=True)
-    captured = capsys.readouterr()
-    assert (
-        captured.out
-        == "Published 'test_message' message on 'test_channel' channel to 0 subscriber(s)\n"
-    )

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -4,7 +4,7 @@ from client_code import messaging
 def test_default_logging(capsys):
     from client_code.logging import DEBUG, Logger
 
-    publisher = messaging.Publisher(logger=Logger(level=DEBUG))
+    publisher = messaging.Publisher(logger=Logger(level=DEBUG, format="{msg}"))
     publisher.publish("test_channel", "test_message")
     captured = capsys.readouterr()
     assert (

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -2,7 +2,8 @@ from client_code import messaging
 
 
 def test_default_logging(capsys):
-    from client_code.logging import Logger, DEBUG
+    from client_code.logging import DEBUG, Logger
+
     publisher = messaging.Publisher(logger=Logger(level=DEBUG))
     publisher.publish("test_channel", "test_message")
     captured = capsys.readouterr()


### PR DESCRIPTION
Added support for receiving a Logger instance as the with_logging parameter in Publisher methods and constructor.
Added support for defining the level for logging in Publisher methods (defaults to INFO).

close #569