### PR TITLE
fix: nodes as targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   https://github.com/anvilistas/anvil-extras/pull/573
 * persistence - linked class attributes were not handling None values correctly
   https://github.com/anvilistas/anvil-extras/pull/577
+* popover - fix bug with popovers not handling dom nodes correctly
+  https://github.com/anvilistas/anvil-extras/pull/580
 
 ## Enhancements
 * tabs - tab color can now be a css var and better support for css colors in general

--- a/client_code/popover.py
+++ b/client_code/popover.py
@@ -387,7 +387,7 @@ class Popover:
     @staticmethod
     def document_sticky_mouseleave_handler(e):
         # did we leave a popover?
-        target = e.target
+        target = _clean_target(e.target)
         if not (target and target.hasAttribute("ae-popover")):
             return
 
@@ -669,8 +669,17 @@ def get_all_parent_popover_ids(target):
     return parent_ids
 
 
+def _clean_target(target):
+    """ensure we are dealing with a dom element and not a node"""
+    if not target:
+        return None
+    if target.nodeType != 1:
+        target = target.parentElement
+    return target
+
+
 def _hide_popovers_on_outside_click(e):
-    target = e.target
+    target = _clean_target(e.target)
     parent_ids = get_all_parent_popover_ids(target)
 
     # Use a copy since the dict changes size during iteration


### PR DESCRIPTION
if the target is a node but not an element then hasAttribute is not a valid method

