### PR TITLE
Added the ability to delete chips with the spacebar and refocusing th…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   https://github.com/anvilistas/anvil-extras/pull/597
 * colors - support colors that update when theme_colors dict is updated
   https://github.com/anvilistas/anvil-extras/pull/599
+* ChipsInput - space will close a chip when selected, and input is focused
+  https://github.com/anvilistas/anvil-extras/pull/587
 
 
 ## Bug Fixes

--- a/client_code/Chip/__init__.py
+++ b/client_code/Chip/__init__.py
@@ -70,8 +70,9 @@ class Chip(ChipTemplate):
         self.init_components(**properties)
 
         def _spacebar_delete_chip(js_event):
-            self.raise_event("close_click")
-            js_event.preventDefault()
+            if js_event.key == " ":
+                self.raise_event("close_click")
+                js_event.preventDefault()
 
         _get_dom_node(self.close_link).addEventListener(
             "keydown", _spacebar_delete_chip

--- a/client_code/Chip/__init__.py
+++ b/client_code/Chip/__init__.py
@@ -68,6 +68,14 @@ class Chip(ChipTemplate):
         )
         properties = _defaults | properties
         self.init_components(**properties)
+
+        def _spacebar_delete_chip(js_event):
+            self.raise_event("close_click")
+            js_event.preventDefault()
+
+        _get_dom_node(self.close_link).addEventListener(
+            "keydown", _spacebar_delete_chip
+        )
         # Any code you write here will run when the form opens.
 
     @property

--- a/client_code/ChipsInput/__init__.py
+++ b/client_code/ChipsInput/__init__.py
@@ -201,6 +201,7 @@ class ChipsInput(ChipsInputTemplate):
         sender.remove_from_parent()
         self.raise_event("chips_changed")
         self.raise_event("chip_removed", chip=chip_text)
+        self.chip_input.focus()
 
     @staticmethod
     def _set_focus(chip, val):


### PR DESCRIPTION
Fixes #585 and #586

#586: I added a JS event handler on ```keydown``` on the ```close_link``` so that the spacebar deletes the chip and doesn't scroll the page (with ```js_event.preventDefault()```).

#585: I used the focus method on the ```chip_input``` text box after all the other code finishes in the ```_chip_close_click``` function.