### PR TITLE
Quill: fix clicking spacer should focus quill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Bug Fixes
+* quill - click guard was not working properly when clicking the spacer below the text
+  https://github.com/anvilistas/anvil-extras/pull/593
+
 # v3.1.0
 
 ## Bug Fixes

--- a/client_code/Quill/__init__.py
+++ b/client_code/Quill/__init__.py
@@ -81,8 +81,10 @@ class Quill(QuillTemplate):
         self._min_height = None
 
         def click_guard(e):
+            # if you click the quill element below the text, you want to focus the editor
+            # but only if you're clicking the spacer itself
             q = self._quill
-            if not q.hasFocus():
+            if not q.hasFocus() and e.srcElement is self._el:
                 q.focus()
                 q.setSelection(len(q.getText()))
 


### PR DESCRIPTION
Raised on the forum
https://anvil.works/forum/t/anvil-extras-quill-link-fix/23710

Basically highlight and make something a link, then try to click the box to change the link url, closed the link tooltip which it shouldn't



