### PR TITLE
Add spacing to slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+## Enhancements
+* slider - add spacing property
+  https://github.com/anvilistas/anvil-extras/pull/597
+
+
 ## Bug Fixes
 * autocomplete - fix bug where escape and enter key should close suggestions
   https://github.com/anvilistas/anvil-extras/discussions/595

--- a/client_code/Slider/__init__.py
+++ b/client_code/Slider/__init__.py
@@ -7,8 +7,10 @@
 
 import anvil.js
 from anvil import HtmlPanel as _HtmlPanel
+from anvil.property_utils import get_unset_margin as _get_unset_margin
+from anvil.property_utils import set_element_margin as _set_margin
 
-from ..utils._component_helpers import _get_color, _html_injector, _spacing_property
+from ..utils._component_helpers import _get_color, _html_injector
 from ._anvil_designer import SliderTemplate
 
 try:
@@ -276,6 +278,14 @@ def _pips_prop(prop):
     return property(_prop_getter(prop), setter)
 
 
+def _margin_prop(prop):
+    def setter(self, value):
+        self._props[prop] = value
+        _set_margin(self._dom_node, value)
+
+    return property(_prop_getter(prop), setter)
+
+
 _defaults = {
     "animate": True,
     "start": 20,
@@ -297,8 +307,7 @@ _defaults = {
     "max": 100,
     "visible": True,
     "enabled": True,
-    "spacing_above": "small",
-    "spacing_below": "small",
+    "margin": None,
     "value": None,
     "values": None,
     "formatted_value": None,
@@ -312,8 +321,7 @@ _defaults = {
 _always = (
     "color",
     "enabled",
-    "spacing_above",
-    "spacing_below",
+    "margin",
     "bar_height",
     "handle_size",
     "role",
@@ -468,11 +476,14 @@ class Slider(SliderTemplate):
     bar_height = _css_length_prop("bar_height", BAR_HEIGHT, 18)
     handle_size = _css_length_prop("handle_size", HANDLE_SIZE, 34)
     color = _color_prop("color", BAR_COLOR)
-    spacing_above = _spacing_property("above")
-    spacing_below = _spacing_property("below")
+    margin = _margin_prop("margin")
     visible = _HtmlPanel.visible
     tag = _HtmlPanel.tag
     role = _HtmlPanel.role
+
+    def _anvil_get_unset_property_values_(self):
+        m = _get_unset_margin(self._dom_node, self.margin)
+        return {"margin": m}
 
     ###### METHODS ######
     def reset(self):

--- a/client_code/Slider/__init__.py
+++ b/client_code/Slider/__init__.py
@@ -39,6 +39,9 @@ _html_injector.css(
 .ae-slider-container.has-pips {{
   padding-bottom: 40px;
 }}
+.anvil-container-overflow, .anvil-panel-col {{
+    overflow: visible;
+}}
 .noUi-connect {{
   background: var({BAR_COLOR});
 }}

--- a/client_code/Slider/__init__.py
+++ b/client_code/Slider/__init__.py
@@ -39,9 +39,6 @@ _html_injector.css(
 .ae-slider-container.has-pips {{
   padding-bottom: 40px;
 }}
-.anvil-container-overflow, .anvil-panel-col {{
-    overflow: visible;
-}}
 .noUi-connect {{
   background: var({BAR_COLOR});
 }}

--- a/client_code/Slider/__init__.py
+++ b/client_code/Slider/__init__.py
@@ -10,7 +10,7 @@ from anvil import HtmlPanel as _HtmlPanel
 from anvil.property_utils import get_unset_spacing as _get_unset_spacing
 from anvil.property_utils import set_element_spacing as _set_spacing
 
-from ..utils._component_helpers import _get_color, _html_injector
+from ..utils._component_helpers import _get_color, _html_injector, _spacing_property
 from ._anvil_designer import SliderTemplate
 
 try:
@@ -304,6 +304,9 @@ _defaults = {
     "max": 100,
     "visible": True,
     "enabled": True,
+    "spacing_above": "small",
+    "spacing_below": "small",
+    "spacing": None,
     "value": None,
     "values": None,
     "formatted_value": None,
@@ -318,6 +321,8 @@ _always = (
     "color",
     "enabled",
     "spacing",
+    "spacing_above",
+    "spacing_below",
     "bar_height",
     "handle_size",
     "role",
@@ -473,6 +478,8 @@ class Slider(SliderTemplate):
     handle_size = _css_length_prop("handle_size", HANDLE_SIZE, 34)
     color = _color_prop("color", BAR_COLOR)
     spacing = _spacing_prop("spacing")
+    spacing_above = _spacing_property("above")
+    spacing_below = _spacing_property("below")
     visible = _HtmlPanel.visible
     tag = _HtmlPanel.tag
     role = _HtmlPanel.role

--- a/client_code/Slider/__init__.py
+++ b/client_code/Slider/__init__.py
@@ -7,8 +7,8 @@
 
 import anvil.js
 from anvil import HtmlPanel as _HtmlPanel
-from anvil.property_utils import get_unset_margin as _get_unset_margin
-from anvil.property_utils import set_element_margin as _set_margin
+from anvil.property_utils import get_unset_spacing as _get_unset_spacing
+from anvil.property_utils import set_element_spacing as _set_spacing
 
 from ..utils._component_helpers import _get_color, _html_injector
 from ._anvil_designer import SliderTemplate
@@ -278,10 +278,10 @@ def _pips_prop(prop):
     return property(_prop_getter(prop), setter)
 
 
-def _margin_prop(prop):
+def _spacing_prop(prop):
     def setter(self, value):
         self._props[prop] = value
-        _set_margin(self._dom_node, value)
+        _set_spacing(self._dom_node, value)
 
     return property(_prop_getter(prop), setter)
 
@@ -307,7 +307,6 @@ _defaults = {
     "max": 100,
     "visible": True,
     "enabled": True,
-    "margin": None,
     "value": None,
     "values": None,
     "formatted_value": None,
@@ -321,7 +320,7 @@ _defaults = {
 _always = (
     "color",
     "enabled",
-    "margin",
+    "spacing",
     "bar_height",
     "handle_size",
     "role",
@@ -476,14 +475,14 @@ class Slider(SliderTemplate):
     bar_height = _css_length_prop("bar_height", BAR_HEIGHT, 18)
     handle_size = _css_length_prop("handle_size", HANDLE_SIZE, 34)
     color = _color_prop("color", BAR_COLOR)
-    margin = _margin_prop("margin")
+    spacing = _spacing_prop("spacing")
     visible = _HtmlPanel.visible
     tag = _HtmlPanel.tag
     role = _HtmlPanel.role
 
     def _anvil_get_unset_property_values_(self):
-        m = _get_unset_margin(self._dom_node, self.margin)
-        return {"margin": m}
+        spacing = _get_unset_spacing(self._dom_node, self._dom_node, self.spacing)
+        return {"spacing": spacing}
 
     ###### METHODS ######
     def reset(self):

--- a/client_code/Slider/form_template.yaml
+++ b/client_code/Slider/form_template.yaml
@@ -33,18 +33,10 @@ properties:
 - {default_value: true, designer_hint: visible, group: appearance, important: true, name: visible, type: boolean}
 - {group: user data, important: false, name: tag, type: object}
 - {default_value: true, designer_hint: enabled, group: interaction, important: true, name: enabled, type: boolean}
-- default_value: small
-  group: layout
+- group: spacing
   important: false
-  name: spacing_above
-  options: [none, small, medium, large]
-  type: enum
-- default_value: small
-  group: layout
-  important: false
-  name: spacing_below
-  options: [none, small, medium, large]
-  type: enum
+  name: margin
+  type: margin
 - {default_value: false, description: Sets whether the slider has pips (ticks), group: pips, important: false, name: pips, type: boolean}
 - {default_value: '', description: '''range'', ''steps'', ''positions'', ''count'', ''values''', group: pips, important: false, name: pips_mode, type: string}
 - {default_value: null, description: 'Controls how many pips are placed. With the default value of 1, there is one pip per percent. For a value of 2, a pip is placed for every 2 percent. A value of zero will place more than one pip per percentage. A value of -1 will remove all intermediate pips.', group: pips, important: false, name: pips_density, type: number}

--- a/client_code/Slider/form_template.yaml
+++ b/client_code/Slider/form_template.yaml
@@ -37,6 +37,20 @@ properties:
   important: false
   name: spacing
   type: spacing
+- default_value: small
+  group: spacing
+  important: false
+  name: spacing_above
+  deprecated: true
+  options: [none, small, medium, large]
+  type: enum
+- default_value: small
+  group: spacing
+  important: false
+  name: spacing_below
+  deprecated: true
+  options: [none, small, medium, large]
+  type: enum
 - {default_value: false, description: Sets whether the slider has pips (ticks), group: pips, important: false, name: pips, type: boolean}
 - {default_value: '', description: '''range'', ''steps'', ''positions'', ''count'', ''values''', group: pips, important: false, name: pips_mode, type: string}
 - {default_value: null, description: 'Controls how many pips are placed. With the default value of 1, there is one pip per percent. For a value of 2, a pip is placed for every 2 percent. A value of zero will place more than one pip per percentage. A value of -1 will remove all intermediate pips.', group: pips, important: false, name: pips_density, type: number}

--- a/client_code/Slider/form_template.yaml
+++ b/client_code/Slider/form_template.yaml
@@ -35,8 +35,8 @@ properties:
 - {default_value: true, designer_hint: enabled, group: interaction, important: true, name: enabled, type: boolean}
 - group: spacing
   important: false
-  name: margin
-  type: margin
+  name: spacing
+  type: spacing
 - {default_value: false, description: Sets whether the slider has pips (ticks), group: pips, important: false, name: pips, type: boolean}
 - {default_value: '', description: '''range'', ''steps'', ''positions'', ''count'', ''values''', group: pips, important: false, name: pips_mode, type: string}
 - {default_value: null, description: 'Controls how many pips are placed. With the default value of 1, there is one pip per percent. For a value of 2, a pip is placed for every 2 percent. A value of zero will place more than one pip per percentage. A value of -1 will remove all intermediate pips.', group: pips, important: false, name: pips_density, type: number}

--- a/docs/guides/components/slider.rst
+++ b/docs/guides/components/slider.rst
@@ -136,13 +136,9 @@ Properties
 
     Is the component visible
 
-:spacing_above: str
+:spacing: spacing
 
-    One of ``"none"``, ``"small"``, ``"medium"``, ``"large"``
-
-:spacing_below: str
-
-    One of ``"none"``, ``"small"``, ``"medium"``, ``"large"``
+    e.g. {"margin": [10, 10], "padding": [10, 10]}
 
 
 


### PR DESCRIPTION
Add a spacing property to the slider component

This is useful since the slider label and pip labels might overflow their container
By supporting customised spacing we no longer need to hack the overflow css of builtin anvil components
(we should remove this hack in a breaking change commit though)


This change is backwards compatible
We deprecate the spacing_above/below properties which will make them not visible in the designer
They will still be applied
but changing the spacing property will override the spacing_above/below values


