### PR TITLE
Set hook

### DIFF
--- a/client_code/ProgressBar/Determinate/__init__.py
+++ b/client_code/ProgressBar/Determinate/__init__.py
@@ -4,10 +4,8 @@
 # https://github.com/anvilistas/anvil-extras/graphs/contributors
 #
 # This software is published at https://github.com/anvilistas/anvil-extras
-from anvil.js import get_dom_node
-
 from anvil_extras import ProgressBar
-from anvil_extras.utils._component_helpers import _css_length, _html_injector
+from anvil_extras.utils._component_helpers import _html_injector, set_hook
 
 from ._anvil_designer import DeterminateTemplate
 
@@ -16,48 +14,11 @@ __version__ = "3.1.0"
 _html_injector.css(ProgressBar.css)
 
 
-class Determinate(DeterminateTemplate):
+class Determinate(ProgressBar.Mixin, DeterminateTemplate):
     def __init__(self, **properties):
-        self.indicator_dom_node = get_dom_node(self.indicator_panel)
-        self.dom_node = get_dom_node(self)
-        self.role = "ae-progress-track"
-        self.indicator_panel.role = "ae-progress-indicator"
-
-        self._props = properties
+        ProgressBar.Mixin.__init__(self, **properties)
         self.init_components(**properties)
 
-    @property
-    def progress(self):
-        return self._props.get("progress")
-
-    @progress.setter
-    def progress(self, value):
-        self._props["progress"] = value
-        self.indicator_dom_node.style.setProperty("width", f"{value:%}")
-
-    @property
-    def height(self):
-        return self._props.get("height")
-
-    @height.setter
-    def height(self, value):
-        self._props["height"] = value
-        self.indicator_dom_node.style.setProperty("height", _css_length(value or 3))
-
-    @property
-    def track_colour(self):
-        return self._props.get("track_colour")
-
-    @track_colour.setter
-    def track_colour(self, value):
-        self._props["track_colour"] = value
-        self.background = value
-
-    @property
-    def indicator_colour(self):
-        return self._props.get("indicator_colour")
-
-    @indicator_colour.setter
-    def indicator_colour(self, value):
-        self._props["indicator_colour"] = value
-        self.indicator_panel.background = value
+    @set_hook
+    def on_set_progress(self):
+        self.set_var("--ae-progress", f"{self.progress:%}")

--- a/client_code/ProgressBar/Determinate/form_template.yaml
+++ b/client_code/ProgressBar/Determinate/form_template.yaml
@@ -1,13 +1,7 @@
-components:
-- components: []
-  data_bindings: []
-  layout_properties: {full_width_row: true, grid_position: 'BSBUXX,ZCPRGS'}
-  name: indicator_panel
-  properties: {background: '', border: '', col_spacing: none, col_widths: '{}', foreground: '', role: null, spacing_above: small, spacing_below: small, tooltip: '', visible: true, wrap_on: mobile}
-  type: ColumnPanel
+components: []
 container:
-  properties: {background: '', border: '', col_spacing: medium, col_widths: '{}', foreground: '', role: null, spacing_above: small, spacing_below: small, tooltip: '', visible: true, wrap_on: mobile}
-  type: ColumnPanel
+  properties: {html: "<div class='ae-progress-bar ae-determinate'><div class='ae-progress-indicator'></div></div>"}
+  type: HtmlTemplate
 custom_component: true
 is_package: true
 properties:

--- a/client_code/ProgressBar/Indeterminate/__init__.py
+++ b/client_code/ProgressBar/Indeterminate/__init__.py
@@ -4,14 +4,8 @@
 # https://github.com/anvilistas/anvil-extras/graphs/contributors
 #
 # This software is published at https://github.com/anvilistas/anvil-extras
-from anvil.js import get_dom_node
-
 from anvil_extras import ProgressBar
-from anvil_extras.utils._component_helpers import (
-    _css_length,
-    _get_color,
-    _html_injector,
-)
+from anvil_extras.utils._component_helpers import _html_injector
 
 from ._anvil_designer import IndeterminateTemplate
 
@@ -20,40 +14,7 @@ __version__ = "3.1.0"
 _html_injector.css(ProgressBar.css)
 
 
-class Indeterminate(IndeterminateTemplate):
+class Indeterminate(ProgressBar.Mixin, IndeterminateTemplate):
     def __init__(self, **properties):
-        self.indicator_dom_node = get_dom_node(self.indicator_panel)
-        self.dom_node = get_dom_node(self)
-        self._props = properties
-        self.role = "ae-progress-track"
-        self.indicator_panel.role = "ae-indeterminate-progress-indicator"
+        ProgressBar.Mixin.__init__(self, **properties)
         self.init_components(**properties)
-
-    @property
-    def height(self):
-        return self._props.get("height")
-
-    @height.setter
-    def height(self, value):
-        self._props["height"] = value
-        self.indicator_dom_node.style.setProperty("height", _css_length(value or 3))
-
-    @property
-    def track_colour(self):
-        return self._props.get("track_colour")
-
-    @track_colour.setter
-    def track_colour(self, value):
-        self._props["track_colour"] = value
-        self.dom_node.style.setProperty(
-            "--ae-track-colour", value and _get_color(value)
-        )
-
-    @property
-    def indicator_colour(self):
-        return self._props.get("indicator_colour")
-
-    @indicator_colour.setter
-    def indicator_colour(self, value):
-        self._props["indicator_colour"] = value
-        self.dom_node.style.setProperty("background-color", _get_color(value))

--- a/client_code/ProgressBar/Indeterminate/form_template.yaml
+++ b/client_code/ProgressBar/Indeterminate/form_template.yaml
@@ -1,13 +1,7 @@
-components:
-- components: []
-  data_bindings: []
-  layout_properties: {full_width_row: true, grid_position: 'BSBUXX,ZCPRGS'}
-  name: indicator_panel
-  properties: {background: '', border: '', col_spacing: medium, col_widths: '{}', foreground: '', role: null, spacing_above: small, spacing_below: small, tooltip: '', visible: true, wrap_on: mobile}
-  type: ColumnPanel
+components: []
 container:
-  properties: {background: '', border: '', col_spacing: medium, col_widths: '{}', foreground: '', role: null, spacing_above: small, spacing_below: small, tooltip: '', visible: true, wrap_on: mobile}
-  type: ColumnPanel
+  properties: {html: "<div class='ae-progress-bar ae-indeterminate'><div class='ae-progress-indicator'></div></div>"}
+  type: HtmlTemplate
 custom_component: true
 is_package: true
 properties:

--- a/client_code/ProgressBar/__init__.py
+++ b/client_code/ProgressBar/__init__.py
@@ -4,32 +4,54 @@
 # https://github.com/anvilistas/anvil-extras/graphs/contributors
 #
 # This software is published at https://github.com/anvilistas/anvil-extras
+import anvil.js
+
+from anvil_extras.utils._component_helpers import _css_length, _get_color, set_hook
+
 __version__ = "3.1.0"
 
-css = """ .anvil-role-ae-progress-track, .anvil-role-ae-progress-indicator {
+css = """ .ae-progress-bar {
     display: block;
     margin: 0;
-}
-
-.anvil-role-ae-progress-track {
+    --ae-bar-height: 3px;
+    --ae-track-color: #b3d4fc;
+    --ae-indicator-color: #1976D2;
+    --ae-progress: 0;
     width: 100%;
+    height: var(--ae-bar-height);
 }
 
-.anvil-role-ae-indeterminate-progress-indicator, .anvil-role-ae-indeterminate-progress-indicator:before {
+.ae-progress-indicator {
+    height: 100%;
+}
+
+.ae-progress-bar.ae-determinate {
+    background-color: var(--ae-track-color);
+}
+
+.ae-progress-bar.ae-indeterminate {
+    background-color: var(--ae-indicator-color);
+}
+
+.ae-determinate .ae-progress-indicator {
+    width: var(--ae-progress);
+    background-color: var(--ae-indicator-color);
+}
+
+.ae-indeterminate .ae-progress-indicator, .ae-indeterminate .ae-progress-indicator:before {
   width: 100%;
   margin: 0;
 }
 
-.anvil-role-ae-indeterminate-progress-indicator {
-  display: -webkit-flex;
+.ae-indeterminate .ae-progress-indicator {
   display: flex;
 }
 
-.anvil-role-ae-indeterminate-progress-indicator:before {
+.ae-indeterminate .ae-progress-indicator:before {
   content: '';
   -webkit-animation: ae-running-progress 2s cubic-bezier(0.4, 0, 0.2, 1) infinite;
   animation: ae-running-progress 2s cubic-bezier(0.4, 0, 0.2, 1) infinite;
-  background-color: var(--ae-track-colour);
+  background-color: var(--ae-track-color);
 }
 
 @-webkit-keyframes ae-running-progress {
@@ -44,3 +66,27 @@ css = """ .anvil-role-ae-progress-track, .anvil-role-ae-progress-indicator {
   100% { margin-left: 100%; margin-right: 0; }
 }
 """
+
+
+class Mixin:
+    def __init_subclass__(cls, **kwargs) -> None:
+        super().__init_subclass__(**kwargs)
+        set_hook.mixin_helper(cls, Mixin)
+
+    def __init__(self, **properties):
+        self.dom_node = anvil.js.get_dom_node(self)
+        self.set_var = self.dom_node.firstChild.style.setProperty
+
+    @set_hook
+    def on_set_height(self):
+        self.set_var("--ae-bar-height", _css_length(self.height or 3))
+
+    @set_hook
+    def on_set_track_colour(self):
+        self.set_var(
+            "--ae-track-color", self.track_colour and _get_color(self.track_colour)
+        )
+
+    @set_hook
+    def on_set_indicator_colour(self):
+        self.set_var("--ae-indicator-color", _get_color(self.indicator_colour))


### PR DESCRIPTION
this PR is an idea for a set hook

for custom components we already have descriptors on the form template
but if we want to do something when we set a property we end up recreating descriptors
what if we could just tap into the existing descriptors on the template

this PR shows that idea

```python
#Before

class C(CTemplate):
    @property
    def text(self):
        return getattr(self, "_text", None)
        
    @text.setter
    def text(self, value):
        self._text = value
        self._some_node.textContent = value

# After

class C(CTemplate):
    @set_hook
    def on_set_text(self):
        self._some_node.textContent = self.text
```

Is it worth it?
Maybe


