### PR TITLE
Fix zerodivision error in MultiSelectDropDown when no options are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   https://github.com/anvilistas/anvil-extras/discussions/595
 * quill - click guard was not working properly when clicking the spacer below the text
   https://github.com/anvilistas/anvil-extras/pull/593
+* multiselect - fix zerodivision error
+  https://github.com/anvilistas/anvil-extras/issues/601
 
 # v3.1.0
 

--- a/client_code/MultiSelectDropDown/DropDown/__init__.py
+++ b/client_code/MultiSelectDropDown/DropDown/__init__.py
@@ -158,6 +158,10 @@ class DropDown(DropDownTemplate):
 
     def _get_next_idx(self, active_idx, dir=1, pred=None):
         num_options = len(self.options)
+
+        if num_options == 0:
+            return -1
+
         if active_idx == -1 and dir == -1:
             active_idx = 0
 


### PR DESCRIPTION
close #601
