### PR TITLE
Sets Multipicker CSS ae-ms-options ul overflow to auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
   https://github.com/anvilistas/anvil-extras/pull/593
 * multiselect - fix zerodivision error
   https://github.com/anvilistas/anvil-extras/issues/601
+* multiselect - reverts the overflow behavior to auto
+  https://github.com/anvilistas/anvil-extras/pull/607
 
 # v3.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Bug Fixes
+* multiselect - reverts the overflow behavior to auto
+  https://github.com/anvilistas/anvil-extras/pull/607
+
 # v3.2.0
 
 ## Enhancements
@@ -18,8 +24,6 @@
   https://github.com/anvilistas/anvil-extras/pull/593
 * multiselect - fix zerodivision error
   https://github.com/anvilistas/anvil-extras/issues/601
-* multiselect - reverts the overflow behavior to auto
-  https://github.com/anvilistas/anvil-extras/pull/607
 
 # v3.1.0
 

--- a/client_code/MultiSelectDropDown/__init__.py
+++ b/client_code/MultiSelectDropDown/__init__.py
@@ -56,7 +56,7 @@ _css = """
     display: flex;
     flex-direction: column;
     height: 100%;
-    overflow: scroll;
+    overflow: auto;
 }
 
 .ae-ms-options a[data-disabled] {


### PR DESCRIPTION
This adopts the auto-scroll property in the multi-select dropdown suggested in this discussion item:

https://github.com/anvilistas/anvil-extras/discussions/606