### PR TITLE
feat: RadioGroup

### DIFF
--- a/.github/workflows/check_codebase.yml
+++ b/.github/workflows/check_codebase.yml
@@ -10,24 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Run pre-commit
+      uses: pre-commit/action@v3.0.1
+      with:
+        extra_args: --all-files
     - name: Install uv and set Python version
       uses: astral-sh/setup-uv@v5
       with:
         python-version: '3.12'
     - name: Install dependencies
       run: |
-        uv pip install flake8 black isort sphinx sphinx_rtd_theme bump2version anvil-uplink marshmallow
-    - name: Lint with flake8
-      run: |
-        uv run flake8 . --count --select=E9,F63,F7,F82 --ignore=E203,E266,E501,W503,F403,F401,E402,F811 --show-source --statistics --exclude=.venv
-        uv run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude=.venv
-    - name: Check format with black
-      run: |
-        uv run black --check . --exclude=.venv
-    - name: Check imports with isort
-      run: |
-        uv run isort --check-only client_code
-        uv run isort --check-only server_code
+        uv pip install sphinx sphinx_rtd_theme bump2version anvil-uplink marshmallow
     - name: Check docs build
       run: |
         uv run sphinx-build docs build

--- a/.github/workflows/check_codebase.yml
+++ b/.github/workflows/check_codebase.yml
@@ -15,13 +15,12 @@ jobs:
       with:
         python-version: '3.12'
         enable-cache: true
-    - name: Run pre-commit
-      uses: pre-commit/action@v3.0.1
-      with:
-        extra_args: --all-files
     - name: Install dependencies
       run: |
-        uv pip install sphinx sphinx_rtd_theme bump2version anvil-uplink marshmallow
+        uv pip install pre-commit sphinx sphinx_rtd_theme bump2version anvil-uplink marshmallow
+    - name: Run pre-commit
+      run: |
+        uv run pre-commit run --all-files
     - name: Check docs build
       run: |
         uv run sphinx-build docs build

--- a/.github/workflows/check_codebase.yml
+++ b/.github/workflows/check_codebase.yml
@@ -30,21 +30,17 @@ jobs:
 
   test:
     name: Tests on Python 3.7
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v4
-    - name: Setup pyenv (3.7.17)
-      uses: gabrielfalcao/pyenv-action@v18
-      with:
-        default: 3.7.17
-        versions: 3.7.17
-    - name: Install uv (tool only)
+    - name: Install uv and Python 3.7
       uses: astral-sh/setup-uv@v5
       with:
         python-version: '3.7'
+        enable-cache: true
     - name: Install test dependencies (3.7-compatible)
       run: |
         uv pip install -r requirements.txt "pytest<8"
     - name: Run test suite (3.7)
       run: |
-        uv run -m pytest
+        uv run python -m pytest

--- a/.github/workflows/check_codebase.yml
+++ b/.github/workflows/check_codebase.yml
@@ -5,21 +5,21 @@ on:
   pull_request:
 
 jobs:
-  check:
-    name: Check code base
+  lint:
+    name: Lint/Docs
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Install uv and set Python version
       uses: astral-sh/setup-uv@v5
       with:
-        python-version: '3.7'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
-        uv pip install flake8 pytest black isort sphinx sphinx_rtd_theme bump2version anvil-uplink marshmallow
+        uv pip install flake8 black isort sphinx sphinx_rtd_theme bump2version anvil-uplink marshmallow
     - name: Lint with flake8
       run: |
-        uv run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude=.venv
+        uv run flake8 . --count --select=E9,F63,F7,F82 --ignore=E203,E266,E501,W503,F403,F401,E402,F811 --show-source --statistics --exclude=.venv
         uv run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude=.venv
     - name: Check format with black
       run: |
@@ -28,12 +28,30 @@ jobs:
       run: |
         uv run isort --check-only client_code
         uv run isort --check-only server_code
-    - name: Run test suite
-      run: |
-        uv run -m pytest
     - name: Check docs build
       run: |
         uv run sphinx-build docs build
     - name: Check version numbering
       run: |
         uv run bumpversion --dry-run patch
+
+  test:
+    name: Tests on Python 3.7
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup pyenv (3.7.17)
+      uses: gabrielfalcao/pyenv-action@v18
+      with:
+        default: 3.7.17
+        versions: 3.7.17
+    - name: Install uv (tool only)
+      uses: astral-sh/setup-uv@v5
+      with:
+        python-version: '3.7'
+    - name: Install test dependencies (3.7-compatible)
+      run: |
+        uv pip install -r requirements.txt "pytest<8"
+    - name: Run test suite (3.7)
+      run: |
+        uv run -m pytest

--- a/.github/workflows/check_codebase.yml
+++ b/.github/workflows/check_codebase.yml
@@ -42,7 +42,7 @@ jobs:
         enable-cache: true
     - name: Install test dependencies (3.8-compatible)
       run: |
-        uv pip install --system -r requirements.txt "pytest<8"
+        uv pip install pytest anvil-uplink marshmallow
     - name: Run test suite (3.8)
       run: |
         python -m pytest

--- a/.github/workflows/check_codebase.yml
+++ b/.github/workflows/check_codebase.yml
@@ -10,14 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Run pre-commit
-      uses: pre-commit/action@v3.0.1
-      with:
-        extra_args: --all-files
     - name: Install uv and set Python version
       uses: astral-sh/setup-uv@v5
       with:
         python-version: '3.12'
+        enable-cache: true
+    - name: Run pre-commit
+      uses: pre-commit/action@v3.0.1
+      with:
+        extra_args: --all-files
     - name: Install dependencies
       run: |
         uv pip install sphinx sphinx_rtd_theme bump2version anvil-uplink marshmallow

--- a/.github/workflows/check_codebase.yml
+++ b/.github/workflows/check_codebase.yml
@@ -31,31 +31,18 @@ jobs:
         uv run bumpversion --dry-run patch
 
   test:
-    name: Tests on Python 3.7
+    name: Tests on Python 3.8
     runs-on: ubuntu-latest
-    timeout-minutes: 10
     steps:
-    - name: Debug runner
-      run: |
-        echo "Runner started"
-        uname -a
-        python3 --version
     - uses: actions/checkout@v4
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.7'
-    - name: Verify Python
-      run: |
-        python --version
-        which python
-    - name: Install uv
+    - name: Install uv and set Python version
       uses: astral-sh/setup-uv@v5
       with:
+        python-version: '3.8'
         enable-cache: true
-    - name: Install test dependencies (3.7-compatible)
+    - name: Install test dependencies (3.8-compatible)
       run: |
         uv pip install --system -r requirements.txt "pytest<8"
-    - name: Run test suite (3.7)
+    - name: Run test suite (3.8)
       run: |
         python -m pytest

--- a/.github/workflows/check_codebase.yml
+++ b/.github/workflows/check_codebase.yml
@@ -2,7 +2,9 @@ name: check_codebase
 
 on:
   push:
+    branches: [main, feat/radio-group]
   pull_request:
+    branches: [main]
 
 jobs:
   lint:
@@ -30,17 +32,30 @@ jobs:
 
   test:
     name: Tests on Python 3.7
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
+    - name: Debug runner
+      run: |
+        echo "Runner started"
+        uname -a
+        python3 --version
     - uses: actions/checkout@v4
-    - name: Install uv and Python 3.7
-      uses: astral-sh/setup-uv@v5
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v4
       with:
         python-version: '3.7'
+    - name: Verify Python
+      run: |
+        python --version
+        which python
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      with:
         enable-cache: true
     - name: Install test dependencies (3.7-compatible)
       run: |
-        uv pip install -r requirements.txt "pytest<8"
+        uv pip install --system -r requirements.txt "pytest<8"
     - name: Run test suite (3.7)
       run: |
-        uv run python -m pytest
+        python -m pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Features
+* RadioGroup - add RadioGroup component
+  https://github.com/anvilistas/anvil-extras/pull/608
+
 ## Bug Fixes
 * multiselect - reverts the overflow behavior to auto
   https://github.com/anvilistas/anvil-extras/pull/607

--- a/__init__.py
+++ b/__init__.py
@@ -4,4 +4,9 @@
 # pip install anvil-uplink
 # python -m anvil.run_app_via_uplink YourAppPackageName
 
-__path__ = [__path__[0] + "/server_code", __path__[0] + "/client_code"]
+import os
+
+__path__ = [
+    os.path.join(os.path.dirname(__file__), "server_code"),
+    os.path.join(os.path.dirname(__file__), "client_code"),
+]

--- a/anvil.yaml
+++ b/anvil.yaml
@@ -12,3 +12,8 @@ services:
   source: /runtime/services/tables.yml
 startup: {module: Demo, type: form}
 startup_form: Demo
+toolbox_sections:
+  - items:
+    - component: {type: anvil_extras.RadioGroup}
+      title: RadioGroup
+    packageName: anvil_extras

--- a/client_code/RadioGroup.py
+++ b/client_code/RadioGroup.py
@@ -1,0 +1,451 @@
+# SPDX-License-Identifier: MIT
+#
+# Copyright (c) 2021 The Anvil Extras project team members listed at
+# https://github.com/anvilistas/anvil-extras/graphs/contributors
+#
+# This software is published at https://github.com/anvilistas/anvil-extras
+
+from functools import partial
+
+import anvil
+from anvil.designer import in_designer
+from anvil.property_utils import (
+    get_unset_spacing,
+    set_element_spacing,
+    set_element_visibility,
+)
+
+from .utils._component_helpers import _css_length, crelt
+
+__version__ = "3.2.0"
+
+DEFAULT_STYLE = (
+    "display: flex; "
+    "align-items: var(--ae-rg-align, center); "
+    "gap: var(--ae-rg-gap, 8px); "
+    "flex-direction: var(--ae-rg-direction, row); "
+    "justify-content: var(--ae-rg-justify, flex-start);"
+)
+if in_designer:
+    DEFAULT_STYLE += "min-height: 40px;"
+
+
+class RadioGroup(anvil.Container):
+    _anvil_events_ = [
+        {"name": "change", "defaultEvent": True},
+        {"name": "show"},
+        {"name": "hide"},
+    ]
+    _anvil_properties_ = [
+        {
+            "name": "selected_value",
+            "type": "object",  # set at runtime
+            "supportsWriteback": True,
+            "important": True,
+            "priority": 10,
+        },
+        {"name": "gap", "type": "string", "group": "layout", "important": True},
+        {"name": "spacing", "type": "spacing", "group": "spacing"},
+        {
+            "name": "direction",
+            "type": "enum",
+            "options": ["horizontal", "vertical"],
+            "includeNoneOption": True,
+            "group": "layout",
+        },
+        {
+            "name": "align",
+            "type": "enum",
+            "options": [
+                "left",
+                "center",
+                "right",
+                "space-evenly",
+                "space-between",
+                "space-around",
+            ],
+            "includeNoneOption": True,
+            "designerHint": "align-horizontal",
+            "group": "layout",
+            "important": True,
+        },
+        {
+            "name": "visible",
+            "type": "boolean",
+            "designerHint": "visible",
+            "group": "appearance",
+        },
+        {"name": "items", "type": "text[]", "important": True},
+        {"name": "class_name", "type": "string", "group": "style"},
+        {"name": "style", "type": "string", "group": "style"},
+        {"name": "buttons", "type": "object"},
+    ]
+    _id = 0
+
+    def __new__(cls, **properties):
+        self = super().__new__(cls)
+        id = cls._id
+        cls._id += 1
+        self._props = {}
+        self.css_vars = {}
+        self._init = False
+        self._name = f"rg-{id}"
+        self._buttons = []
+        self._dom = crelt(
+            "div",
+            style=DEFAULT_STYLE,
+            role="radiogroup",
+            ariaOrientation="horizontal",  # default orientation corresponds to row
+        )
+        self._placeholder = crelt(
+            "div", style="font-style: italic; margin: auto; opacity: 0.3;"
+        )
+        self._placeholder.textContent = "Add RadioButtons or set .items"
+        self._dropzones = []
+        self._item_values = {}
+
+        if in_designer:
+            self._dom.append(self._placeholder)
+
+        self.add_event_handler(
+            "x-anvil-classic-show", lambda **e: self.raise_event("show")
+        )
+        self.add_event_handler(
+            "x-anvil-classic-hide", lambda **e: self.raise_event("hide")
+        )
+
+        return self
+
+    def __init__(
+        self,
+        items=None,
+        selected_value=None,
+        gap=8,
+        spacing=None,
+        direction=None,
+        align=None,
+        visible=True,
+        buttons=None,
+        class_name=None,
+        style=None,
+        **properties,
+    ):
+        super().__init__()
+        self.gap = gap
+        self.spacing = spacing
+        self.direction = direction
+        self.align = align
+        self.items = items
+        self.visible = visible
+        self.class_name = class_name
+        self.style = style
+        if buttons is not None:
+            self.buttons = buttons
+        # enable style application and compose once
+        self._init = True
+        self._apply_style()
+        self.selected_value = selected_value
+
+    def add_component(self, c, index=None, **layout_props):
+        self._placeholder.remove()
+
+        super().add_component(
+            c, index=index, on_remove=partial(self._remove_component, c)
+        )
+
+        real_index = self.get_components().index(c)
+        child = self._dom.children.get(real_index)
+        dom_node = c._anvil_setup_dom_()
+        # wrapper is purely presentational and fixes a bootstrap annoying style issue
+        wrapper = crelt("div", role="none")
+        wrapper.append(dom_node)
+        if child:
+            self._dom.insertBefore(wrapper, child)
+        else:
+            self._dom.appendChild(wrapper)
+
+        if isinstance(c, anvil.RadioButton):
+            self._add_button(c)
+
+    def _remove_component(self, c):
+        if isinstance(c, anvil.RadioButton):
+            self._remove_button(c)
+
+        # remove the wrapper we added in add_component (if present)
+        el = c._anvil_dom_element_
+        wrapper = el.parentNode
+        if wrapper is not None:
+            wrapper.remove()
+
+        if in_designer and not self.get_components():
+            self._dom.append(self._placeholder)
+
+    def _anvil_get_unset_property_values_(self):
+        dom = self._dom
+        sp = get_unset_spacing(dom, dom, self.spacing)
+        return {"spacing": sp}
+
+    def _gen_drop_zone(self):
+        el = crelt("div")
+        index = len(self._dropzones)
+        dz = {
+            "element": el,
+            "dropInfo": {
+                "minChildIdx": index,
+                "maxChildIdx": index,
+            },
+        }
+        self._dropzones.append(dz)
+        return dz
+
+    def _anvil_enable_drop_mode_(self, *args):
+        self._anvil_disable_drop_mode_()
+        self._placeholder.remove()
+
+        children = list(self._dom.children)
+        for c in children:
+            dz = self._gen_drop_zone()
+            c.insertAdjacentElement("beforebegin", dz["element"])
+
+        dz = self._gen_drop_zone()
+        self._dom.insertAdjacentElement("beforeend", dz["element"])
+
+        return self._dropzones
+
+    def _anvil_disable_drop_mode_(self):
+        for dz in self._dropzones:
+            dz["element"].remove()
+
+        self._dropzones = []
+        if not self.get_components():
+            self._dom.append(self._placeholder)
+
+    def _anvil_setup_dom_(self):
+        return self._dom
+
+    @property
+    def _anvil_dom_element_(self):
+        return self._dom
+
+    @property
+    def buttons(self):
+        return self._buttons
+
+    @buttons.setter
+    def buttons(self, v):
+        handler = self._handle_button_change
+
+        prev_buttons = self._buttons
+        for b in prev_buttons:
+            b.remove_event_handler("change", handler)
+            b.group_name = None
+
+        self._buttons = list(v or [])
+
+        for b in self._buttons:
+            b.add_event_handler("change", handler)
+            b.group_name = self._name
+
+    def _add_button(self, b):
+        self._buttons.append(b)
+        b.add_event_handler("change", self._handle_button_change)
+        b.group_name = self._name
+
+    def _remove_button(self, b):
+        self._buttons.remove(b)
+        b.remove_event_handler("change", self._handle_button_change)
+        b.group_name = None
+        if self._selected_button is b:
+            self._selected_button = None
+
+    def _handle_button_change(self, **event_args):
+        self._handle_change()
+
+    def _handle_change(self):
+        self.raise_event("x-anvil-write-back-selected_value")
+        self.raise_event("change")
+
+    @property
+    def _selected_button(self):
+        for button in self._buttons:
+            if button.selected:
+                return button
+        return None
+
+    @_selected_button.setter
+    def _selected_button(self, button):
+        if button is None:
+            # Deselect the currently selected button
+            _selected_button = self._selected_button
+            if _selected_button:
+                _selected_button.selected = False
+        else:
+            if button not in self._buttons:
+                raise ValueError("RadioButton is not in this group")
+            button.selected = True
+
+    @property
+    def selected_value(self):
+        button = self._selected_button
+        if button is None:
+            return None
+        else:
+            return self._item_values.get(button, button.value)
+
+    @selected_value.setter
+    def selected_value(self, requested_value):
+        item_values = self._item_values
+        for button in self._buttons:
+            if item_values.get(button, button.value) == requested_value:
+                self._selected_button = button
+                return
+        self._selected_button = None
+
+    @property
+    def gap(self):
+        return self._props.get("gap")
+
+    @gap.setter
+    def gap(self, value):
+        self._props["gap"] = value
+        self.css_vars["gap"] = _css_length(value)
+        self._apply_style()
+
+    @property
+    def direction(self):
+        return self._props.get("direction")
+
+    @direction.setter
+    def direction(self, value):
+        self._props["direction"] = value
+        dir_val = "column" if value == "vertical" else "row"
+        self.css_vars["direction"] = dir_val
+        if value == "vertical":
+            self._dom.setAttribute("aria-orientation", "vertical")
+        else:
+            self._dom.setAttribute("aria-orientation", "horizontal")
+
+        self._set_align_vars()
+        self._apply_style()
+
+    @property
+    def spacing(self):
+        return self._props.get("spacing")
+
+    @spacing.setter
+    def spacing(self, value):
+        self._props["spacing"] = value
+        set_element_spacing(self._dom, value)
+
+    @property
+    def visible(self):
+        return self._props.get("visible")
+
+    @visible.setter
+    def visible(self, value):
+        self._props["visible"] = value
+        set_element_visibility(self._dom, value)
+        # reflect visibility state for assistive tech
+        self._dom.setAttribute("aria-hidden", "false" if value else "true")
+
+    def _apply_style(self):
+        """Compose inline style as: VARS + DEFAULT_STYLE + user style."""
+        # Skip during construction to avoid repeated recomposition
+        if not self._init:
+            return
+        parts = "".join(f"--ae-rg-{k}: {v};" for k, v in self.css_vars.items())
+        user_style = self._props.get("style") or ""
+        composed = parts + " " + DEFAULT_STYLE + " " + user_style
+        self._dom.setAttribute("style", composed)
+        # Re-apply spacing after resetting inline style so margins persist
+        sp = self._props.get("spacing")
+        if sp is not None:
+            set_element_spacing(self._dom, sp)
+
+    def _set_align_vars(self):
+        """Derive --align/--justify based on current align and direction."""
+        align_val = self._props.get("align")
+        # Clear to defaults when unset
+        if not align_val:
+            self.css_vars.pop("align", None)
+            self.css_vars.pop("justify", None)
+            return
+        if align_val == "left":
+            css = "flex-start"
+        elif align_val == "right":
+            css = "flex-end"
+        else:
+            css = align_val
+        dir_val = self.css_vars.get("direction") or (
+            "column" if self._props.get("direction") == "vertical" else "row"
+        )
+        if dir_val == "column":
+            self.css_vars["align"] = css
+            self.css_vars.pop("justify", None)
+        else:
+            self.css_vars["justify"] = css
+            self.css_vars.pop("align", None)
+
+    @property
+    def class_name(self):
+        return self._props.get("class_name")
+
+    @class_name.setter
+    def class_name(self, value):
+        self._props["class_name"] = value
+        self._dom.className = value or ""
+
+    @property
+    def style(self):
+        return self._props.get("style")
+
+    @style.setter
+    def style(self, value):
+        self._props["style"] = value or ""
+        self._apply_style()
+
+    @property
+    def align(self):
+        return self._props.get("align")
+
+    @align.setter
+    def align(self, value):
+        self._props["align"] = value
+        self._set_align_vars()
+        self._apply_style()
+
+    @property
+    def items(self):
+        return self._props.get("items")
+
+    @items.setter
+    def items(self, value):
+        self._props["items"] = value
+        item_values = {}
+        buttons = []
+        selected_value = self.selected_value
+        value = value or []
+
+        for i, item in enumerate(value):
+            if isinstance(item, str):
+                text = value = real_value = item
+            elif isinstance(item, (tuple, list)):
+                text, real_value = item
+                value = str(i)
+            else:
+                raise TypeError(
+                    f"item at index {i} is not a str or tuple, got {type(item)}"
+                )
+
+            b = anvil.RadioButton(
+                text=text,
+                value=value,
+                selected=selected_value == real_value,
+            )
+            item_values[b] = real_value
+            buttons.append(b)
+
+        self.clear()
+        for b in buttons:
+            self.add_component(b)
+        self._item_values = item_values

--- a/client_code/utils/_component_helpers.py
+++ b/client_code/utils/_component_helpers.py
@@ -239,3 +239,27 @@ def _remove_roles(self, roles):
     updated_roles = [role for role in current_roles if role not in roles_to_remove]
 
     self.role = updated_roles
+
+
+def _to_kebab(s: str) -> str:
+    return "".join(("-" + c.lower()) if c.isupper() else c for c in s).lstrip("-")
+
+
+def _normalize_attr_name(attr_name: str) -> str:
+    if attr_name == "className":
+        return "class"
+    if attr_name == "htmlFor":
+        return "for"
+    return _to_kebab(attr_name)
+
+
+def crelt(node_type: str, **attrs):
+    el = _document.createElement(node_type)
+
+    for attr, value in attrs.items():
+        if value is None:
+            continue
+        norm_name = _normalize_attr_name(attr)
+        el.setAttribute(norm_name, value)
+
+    return el

--- a/docs/guides/components/radio_group.rst
+++ b/docs/guides/components/radio_group.rst
@@ -1,0 +1,159 @@
+RadioGroup
+===========
+
+A flexible container that groups multiple ``anvil.RadioButton`` components so that only one
+can be selected at a time. You can either:
+
+- add individual ``RadioButton`` components as children of the group, or
+- set the ``items`` property (similar to an Anvil ``Dropdown``) to auto-generate buttons.
+
+The currently selected value is exposed via ``selected_value`` and a ``change`` event
+is fired whenever the selection changes.
+
+
+Usage
+-----
+
+Add as a container and append buttons
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+    from anvil import RadioButton
+    from anvil_extras import RadioGroup
+
+
+    class Form(FormTemplate):
+        def __init__(self, **properties):
+            # You can do this in code or via the Designer:
+            # - Designer: Drag a RadioGroup onto your form, then drop RadioButtons into it.
+            # - Code: Create a RadioGroup and add RadioButtons as children.
+            self.radio_group = RadioGroup()
+            self.add_component(self.radio_group)
+            self.radio_group.add_component(RadioButton(text="Option A", value="a"))
+            self.radio_group.add_component(RadioButton(text="Option B", value="b"))
+            self.radio_group.add_event_handler("change", self.radio_group_change)
+
+    def radio_group_change(self, **event_args):
+        # Read the logical value of the selected option
+        print(self.radio_group.selected_value)  # -> "a" or "b"
+
+
+
+Use the items property (like Dropdown)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``items`` may be a list of strings or a list of ``(text, value)`` tuples:
+
+.. code-block:: python
+
+    from anvil_extras import RadioGroup
+
+    # Simple list of strings: value equals the text
+    self.radio_group = RadioGroup(items=["One", "Two", "Three"])  # selected_value is one of the strings
+
+    # List of (text, value) pairs: logical value is separate from the label
+    self.radio_group.items = [("Apples", "apples"), ("Oranges", "oranges"), ("Pears", "pears")]
+
+    # Reading the selection returns the logical value (e.g. "oranges"):
+    print(self.radio_group.selected_value)
+
+    # Programmatic selection: set the logical value directly
+    self.radio_group.selected_value = "oranges"  # selects "Oranges"
+
+
+Group existing RadioButtons on your form
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you already have individual ``RadioButton`` components on a form, you can group them:
+
+.. code-block:: python
+
+    from anvil_extras import RadioGroup
+
+    # If you already have RadioButtons on your form (e.g. placed in the Designer),
+    # you can add group behaviour without moving them into the RadioGroup container.
+    # This is especially useful when buttons may not be on-screen yet and
+    # radio_buttons.group_value would otherwise be None.
+    # The group ensures mutual exclusivity and consistent change events.
+    self.radio_group = RadioGroup()
+    self.radio_group.buttons = [self.radio_button_1, self.radio_button_2]
+    self.radio_group.add_event_handler("change", self.radio_group_change)
+
+    # Alternatively, pass the buttons in the constructor
+    self.radio_group = RadioGroup(buttons=[self.radio_button_1, self.radio_button_2])
+    self.radio_group.add_event_handler("change", self.radio_group_change)
+
+
+Properties
+----------
+
+:selected_value: object | None
+
+    The logical value of the selected option. When using ``items`` with ``(text, value)``
+    pairs, this returns the ``value`` part. When using a list of strings, this is the string.
+    Set to a matching value to programmatically select an option, or to ``None`` to clear.
+
+:gap: string | float | int
+
+    Spacing between radio buttons. Accepts a number (pixels) or a CSS length string
+    (e.g. ``"12px"``, ``"0.5rem"``).
+
+:spacing: spacing
+
+    Standard Anvil container spacing
+
+:direction: enum
+
+    Layout direction of the group: ``"horizontal"`` (default) or ``"vertical"``.
+
+:align: enum
+
+    Alignment of buttons within the group. One of
+    ``"left"``, ``"center"``, ``"right"``, ``"space-evenly"``, ``"space-between"``,
+    ``"space-around"``. In horizontal layout this controls horizontal distribution;
+    in vertical layout it controls cross-axis alignment.
+
+:visible: bool
+
+    Whether the component is visible.
+
+:items: list[str] | list[tuple[str, Any]]
+
+    Use to auto-generate buttons. Strings produce labels with the same value; tuples
+    of ``(text, value)`` let you separate display text and logical value.
+
+:buttons: list[anvil.RadioButton]
+
+    Assign an explicit list of existing ``RadioButton`` components to be managed by
+    the group. When set, event handlers are attached and the buttons are grouped so
+    only one can be selected at a time. You can also provide this in the constructor,
+    e.g. ``RadioGroup(buttons=[rb1, rb2])``.
+
+
+Events
+------
+
+:change:
+
+    Fired when the selection changes. This is the default event. Use
+    ``self.radio_group.selected_value`` inside the handler to read the current value.
+
+:show:
+
+    Fired when the component is shown.
+
+:hide:
+
+    Fired when the component is hidden.
+
+
+Notes
+-----
+
+- When ``items`` contains ``(text, value)`` pairs, ``selected_value`` returns the
+  ``value``; with a simple list of strings, it returns the string itself.
+- Setting ``selected_value`` to a value that doesn't exist will clear the selection.
+- For tuple ``items``, set ``selected_value`` to the tuple's logical value (e.g. ``"oranges"``)
+  at any time to select that option.
+- ``align="left"``/``"right"`` map to flexbox ``flex-start``/``flex-end`` under the hood.


### PR DESCRIPTION
Adds a RadioGroup component
uses some of the undocumented anvil component syntax
which I only really used because i needed the cleanup function when a RadioButton is removed

This fixes the issue:
https://anvil.works/forum/t/bug-with-radio-button-group-value-on-forms-not-in-page/11404

you just need to to add a RadioGroup to your existing form
`self.rg = RadioGroup(buttons=[self.radio_button_1])`

but it also can be used as container in the designer
or dropdown like approach where you just set the `.items` property


