### PR TITLE
Remove .anvil-panel-col selector from the Slider's styling

### DIFF
--- a/client_code/Slider/__init__.py
+++ b/client_code/Slider/__init__.py
@@ -39,7 +39,7 @@ _html_injector.css(
 .ae-slider-container.has-pips {{
   padding-bottom: 40px;
 }}
-.anvil-container-overflow, .anvil-panel-col {{
+.anvil-container-overflow {{
     overflow: visible;
 }}
 .noUi-connect {{


### PR DESCRIPTION
The selector is redundant and breaks other components where overflow should be hidden.

The slider behaves as expected without it.