### PR TITLE
Slider: remove overflow hidden overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+## Bug Fixes
+* slider - remove overflow css override that broke some other anvil components
+https://github.com/anvilistas/anvil-extras/pull/610
+
+
 # v3.3.0
 
 ## Features

--- a/client_code/Slider/__init__.py
+++ b/client_code/Slider/__init__.py
@@ -454,7 +454,7 @@ class Slider(SliderTemplate):
         for tooltip, origin in zip(self._tooltips, self._origins):
             _document.body.append(tooltip)
             cleanup = auto_update(
-                origin.firstElementChild.firstElementChild,
+                origin.firstElementChild,
                 tooltip,
                 placement="top",
                 arrow=None,

--- a/client_code/Slider/__init__.py
+++ b/client_code/Slider/__init__.py
@@ -419,7 +419,7 @@ class Slider(SliderTemplate):
         for tooltip, origin in zip(self._tooltips, self._origins):
             _document.body.append(tooltip)
             cleanup = auto_update(
-                origin.firstElementChild,
+                origin.firstElementChild.firstElementChild,
                 tooltip,
                 placement="top",
                 arrow=None,

--- a/client_code/Slider/__init__.py
+++ b/client_code/Slider/__init__.py
@@ -409,17 +409,15 @@ class Slider(SliderTemplate):
                 e = e.original_error.message
             raise RuntimeError(repr(e).replace("noUiSlider", "Slider"))
 
-        self._tooltips = self._slider.getTooltips()
-        for tooltip in self._tooltips:
-            _document.body.append(tooltip)
-
-        self._origins = self._slider.getOrigins()
-
         for cleanup in self._fui_cleanup:
             cleanup()
 
+        self._tooltips = self._slider.getTooltips()
+        self._origins = self._slider.getOrigins()
         self._fui_cleanup = []
+
         for tooltip, origin in zip(self._tooltips, self._origins):
+            _document.body.append(tooltip)
             cleanup = auto_update(
                 origin.firstElementChild,
                 tooltip,

--- a/client_code/Slider/__init__.py
+++ b/client_code/Slider/__init__.py
@@ -358,6 +358,7 @@ class Slider(SliderTemplate):
         self._fui_cleanup = []
         self._slider = None
         self._tap_timeout_id = None
+        self._debounce_timeout_id = None
         try:
             self._parse_props()
             self._create_slider()
@@ -430,10 +431,19 @@ class Slider(SliderTemplate):
             self._update_tooltip_positions()
 
     def _handle_slider_event(self, tap):
+        # Clear existing timeouts
+        clearTimeout(self._tap_timeout_id)
+        clearTimeout(self._debounce_timeout_id)
+
         if tap:
-            setTimeout(self._update_tooltip_positions, 300)
-        else:
+            # For tap events, update immediately and after animation
             self._update_tooltip_positions()
+            self._tap_timeout_id = setTimeout(self._update_tooltip_positions, 300)
+        else:
+            # For drag events, debounce to avoid excessive updates
+            self._debounce_timeout_id = setTimeout(
+                self._update_tooltip_positions, 16
+            )  # ~60fps
 
     def _update_tooltip_positions(self):
         for cleanup in self._fui_cleanup:

--- a/client_code/Slider/__init__.py
+++ b/client_code/Slider/__init__.py
@@ -7,9 +7,9 @@
 
 import anvil.js
 from anvil import HtmlPanel as _HtmlPanel
-from anvil.js.window import clearTimeout
+from anvil.js.window import cancelAnimationFrame, clearTimeout
 from anvil.js.window import document as _document
-from anvil.js.window import setTimeout
+from anvil.js.window import requestAnimationFrame, setTimeout
 from anvil.property_utils import get_unset_spacing as _get_unset_spacing
 from anvil.property_utils import set_element_spacing as _set_spacing
 
@@ -358,7 +358,7 @@ class Slider(SliderTemplate):
         self._fui_cleanup = []
         self._slider = None
         self._tap_timeout_id = None
-        self._debounce_timeout_id = None
+        self._animation_frame_id = None
         try:
             self._parse_props()
             self._create_slider()
@@ -431,19 +431,19 @@ class Slider(SliderTemplate):
             self._update_tooltip_positions()
 
     def _handle_slider_event(self, tap):
-        # Clear existing timeouts
+        # Clear existing timeouts and animation frames
         clearTimeout(self._tap_timeout_id)
-        clearTimeout(self._debounce_timeout_id)
+        cancelAnimationFrame(self._animation_frame_id)
 
         if tap:
             # For tap events, update immediately and after animation
             self._update_tooltip_positions()
             self._tap_timeout_id = setTimeout(self._update_tooltip_positions, 300)
         else:
-            # For drag events, debounce to avoid excessive updates
-            self._debounce_timeout_id = setTimeout(
-                self._update_tooltip_positions, 16
-            )  # ~60fps
+            # For drag events, use requestAnimationFrame for smooth updates
+            self._animation_frame_id = requestAnimationFrame(
+                self._update_tooltip_positions
+            )
 
     def _update_tooltip_positions(self):
         for cleanup in self._fui_cleanup:

--- a/client_code/Slider/__init__.py
+++ b/client_code/Slider/__init__.py
@@ -414,8 +414,11 @@ class Slider(SliderTemplate):
 
         ###### EVENTS ######
         self._slider.on("slide", lambda v, h, *e: self.raise_event("slide", handle=h))
-        self._slider.on("set", lambda v, h, *e: self._update_tooltip_positions())
         self._slider.on("change", lambda v, h, *e: self.raise_event("change", handle=h))
+        self._slider.on(
+            "slide", lambda v, h, u, tap, *e: self._handle_slider_event(tap)
+        )
+        self._slider.on("set", lambda v, h, u, tap, *e: self._handle_slider_event(tap))
 
     def _update_tooltip_visibility(self, **kws):
         """Update tooltip visibility to match their origins when tooltips are on body"""
@@ -424,6 +427,12 @@ class Slider(SliderTemplate):
             tooltip.style.display = "block" if visible else "none"
 
         if visible:
+            self._update_tooltip_positions()
+
+    def _handle_slider_event(self, tap):
+        if tap:
+            setTimeout(self._update_tooltip_positions, 300)
+        else:
             self._update_tooltip_positions()
 
     def _update_tooltip_positions(self):

--- a/client_code/Slider/__init__.py
+++ b/client_code/Slider/__init__.py
@@ -13,6 +13,7 @@ from anvil.js.window import setTimeout
 from anvil.property_utils import get_unset_spacing as _get_unset_spacing
 from anvil.property_utils import set_element_spacing as _set_spacing
 
+from ..fui import auto_update
 from ..utils._component_helpers import _get_color, _html_injector, _spacing_property
 from ._anvil_designer import SliderTemplate
 
@@ -408,13 +409,20 @@ class Slider(SliderTemplate):
             raise RuntimeError(repr(e).replace("noUiSlider", "Slider"))
 
         self._tooltips = self._slider.getTooltips()
-        for tooltip in self._tooltips:
-            _document.body.append(tooltip)
+        # for tooltip in self._tooltips:
+        #     _document.body.append(tooltip)
 
         self._origins = self._slider.getOrigins()
 
         # Initial tooltip positioning
-        self._update_tooltip_positions()
+        for tooltip, origin in zip(self._tooltips, self._origins):
+            auto_update(
+                origin.firstElementChild,
+                tooltip,
+                placement="top",
+                arrow=None,
+            )
+        # self._update_tooltip_positions()
 
         ###### EVENTS ######
 
@@ -461,6 +469,8 @@ class Slider(SliderTemplate):
 
     def _update_tooltip_positions(self):
         """Update tooltip positions to match their origins when tooltips are on body"""
+        return
+
         for tooltip, origin in zip(self._tooltips, self._origins):
             if tooltip and origin:
                 # Get the actual handle element (first child of origin)

--- a/client_code/Slider/__init__.py
+++ b/client_code/Slider/__init__.py
@@ -445,7 +445,7 @@ class Slider(SliderTemplate):
                 self._update_tooltip_positions
             )
 
-    def _update_tooltip_positions(self):
+    def _update_tooltip_positions(self, *e):
         for cleanup in self._fui_cleanup:
             cleanup()
 

--- a/client_code/fui.py
+++ b/client_code/fui.py
@@ -56,6 +56,7 @@ def auto_update(
     offset = 11 if arrow else 4
 
     def update(*args):
+        print("update")
         middleware = [
             FloatingUIDOM.offset(offset),
             FloatingUIDOM.flip(),

--- a/client_code/fui.py
+++ b/client_code/fui.py
@@ -56,7 +56,6 @@ def auto_update(
     offset = 11 if arrow else 4
 
     def update(*args):
-        print("update")
         middleware = [
             FloatingUIDOM.offset(offset),
             FloatingUIDOM.flip(),


### PR DESCRIPTION
To remove the overflow hidden overrides as hoped in #609 

This PR moves the tooltips to the body
and uses our internal tooltip implementation to keep the tooltips in the right place

