### PR TITLE
implement autocomplete with pluggable_ui textbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+## Enhancements
+* autocomplete - use default textbox implementation (e.g. m3 apps will use m3 textbox)
+  adds virtualization for large suggestion lists
+  https://github.com/anvilistas/anvil-extras/pull/615
+
 # v3.3.1
 
 ## Bug Fixes

--- a/client_code/Autocomplete/form_template.yaml
+++ b/client_code/Autocomplete/form_template.yaml
@@ -1,5 +1,5 @@
 container:
-  event_bindings: {hide: _on_hide, show: _on_show}
+  event_bindings: {}
   properties: {}
   type: TextBox
 custom_component: true


### PR DESCRIPTION
Considerations: this is not documented api

Since m3 overrides the pluggable_ui["anvil.TextBox"]
It means that anyone using an autocomplete component in an m3 app will get an m3 textbox instead of an anvil textbox,
which is probably what they want, but might be unexpected
especially if they've added some css

Might be considered breaking, but I think it's probably an enhancement??


Also adds virtualization, since we added it for the other list rendering component, why not


addresses discussion #603 

