### PR TITLE
Fix: wrap view transition in try except to mitigate against random errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
   adds virtualization for large suggestion lists
   https://github.com/anvilistas/anvil-extras/pull/615
 
+## Bug Fixes
+* routing - avoid view transition random errors
+  https://github.com/anvilistas/anvil-extras/pull/616
+
 # v3.3.1
 
 ## Bug Fixes


### PR DESCRIPTION
not sure this is the right fix, but wrapping it in a try except might work

trying to avoid the random error about invalid state
see:
https://anvil.works/forum/t/anyone-seen-invalidstateerror-view-transition-was-skipped-because-document-visibility-state-is-hidden-with-anvil-router/24990/6


