### PR TITLE
Fix: chrome tablet focus issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Bug Fixes
+- multiselect - fix bug on chrome tablet where focus was lost from search box
+  https://github.com/anvilistas/anvil-extras/pull/627
+
 # v3.4.1
 
 ## Bug Fixes

--- a/client_code/MultiSelectDropDown/DropDown/__init__.py
+++ b/client_code/MultiSelectDropDown/DropDown/__init__.py
@@ -520,6 +520,10 @@ class DropDown(DropDownTemplate):
         """Ensure keydown continues to be received after scroll/renders.
         We prefer to keep focus within the options container so Arrow keys work.
         """
+        if self.enable_filtering:
+            # Fixes an issue on chrome tablets, where the focus is lost when the search box is focused
+            return
+
         active = document.activeElement
 
         if active and self.dd_node.contains(active):


### PR DESCRIPTION
a quick fix for preventing the search filter box from losing focus immediately after it receives focus

fixes #626