### PR TITLE
Routing: fix circular import issues with lazy_route

### DIFF
--- a/client_code/routing/_decorators.py
+++ b/client_code/routing/_decorators.py
@@ -102,13 +102,17 @@ def lazy_route(
 
     def wrapper(fn):
         class Lazy:
-            _form = None
+            _form_async_call = None
 
             def __new__(cls, **properties):
-                form_class = cls._form
-                if form_class is None:
-                    form_class = cls._form = fn()
-                return form_class.__new__(form_class, **properties)
+                form_async_call = cls._form_async_call
+                if form_async_call is None:
+                    from ..non_blocking import call_async
+
+                    form_async_call = cls._form_async_call = call_async(fn)
+
+                form = form_async_call.await_result()
+                return form.__new__(form, **properties)
 
         route_wrapper(Lazy)
         return fn

--- a/client_code/routing/_router.py
+++ b/client_code/routing/_router.py
@@ -164,6 +164,9 @@ def navigate(url_hash=None, url_pattern=None, url_dict=None, **properties):
             )
         else:
             logger.debug(f"loading route: {form.__class__.__name__!r} from cache")
+
+        nav_context.check_stale()
+
         with ViewTransition(form):
             clear_container()
             nav_context.check_stale()


### PR DESCRIPTION
If a lazy route results in a module that takes a while to load
then a trigger happy user can cause this lazy route to be called multiple times
this results in false positive circular import errors occuring
(whilst a module is being imported, the same module gets imported)

This PR prevents inflight calls to lazy routes by using the existing non_blocking machinery
In this PR we can only ever have one inflight call to the same lazy route


