### PR TITLE
fix(MultiSelectDropDown): preserve selection when items are reset

### DIFF
--- a/client_code/MultiSelectDropDown/__init__.py
+++ b/client_code/MultiSelectDropDown/__init__.py
@@ -332,11 +332,21 @@ class MultiSelectDropDown(MultiSelectDropDownTemplate):
 
     @items.setter
     def items(self, value):
+        # Preserve current selection so refreshes don't clear valid values.
+        pending_selected = list(self._invalid)
+        if self._options_built:
+            pending_selected = [
+                opt["value"]
+                for opt in self._options
+                if not opt.get("is_divider") and opt.get("selected")
+            ] + pending_selected
+
         # store raw items and mark for lazy build
         self._props["items"] = value
         self._raw_items = list(value) if value else []
         self._options_built = False
         self._options = []  # list[dict]
+        self._invalid = pending_selected
         self._dd.options = []  # html renderer expects list[dict]
         self._total = 0
 


### PR DESCRIPTION
## Summary
- preserve current selected values when `MultiSelectDropDown.items` is updated
- keep pending invalid selections queued for lazy rebuild
- ensure lazy rebuild re-applies still-valid selections instead of clearing state

## Validation
- manual testing against the clone in 647

Closes #647
